### PR TITLE
Add quotes to names in sql queries to allow keywords as table names and columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+
+### Fixed
 - Add quotes to all names in sql queries to allow keywords as table or column names
 
 ## [0.6.0] - 2018-09-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Addded
+### Added
 
 ### Changed
+- Add quotes to all names in sql queries to allow keywords as table or column names
 
 ## [0.6.0] - 2018-09-05
 

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -98,11 +98,15 @@ export default () => [
 
       // some records
       expectSortedEqual(await adapter.query(taskQuery(Q.where('bool1', false))), ['t1', 't3'])
+      expectSortedEqual(await adapter.query(taskQuery(Q.where('order', 2))), ['t2'])
+      expectSortedEqual(await adapter.query(taskQuery(Q.where('order', 3))), ['t3'])
+
       expect(await adapter.count(taskQuery(Q.where('bool1', false)))).toBe(2)
 
       // no records
       expectSortedEqual(await adapter.query(taskQuery(Q.where('text1', 'nope'))), [])
       expect(await adapter.count(taskQuery(Q.where('text1', 'nope')))).toBe(0)
+      expect(await adapter.count(taskQuery(Q.where('order', 4)))).toBe(0)
     },
   ],
   [
@@ -190,7 +194,7 @@ export default () => [
 
       m1._isEditing = true
       m1._setRaw('bool1', true)
-      const m2 = makeMockTask({ id: 't2', text1: 'bar', bool2: true })
+      const m2 = makeMockTask({ id: 't2', text1: 'bar', bool2: true, order: 2 })
 
       await adapter.batch([
         ['create', m3],
@@ -241,11 +245,13 @@ export default () => [
       await adapter.batch([['create', record]])
       record._isEditing = true
       record._setRaw('bool1', true)
+      record._setRaw('order', 2)
       await adapter.batch([['update', record]])
       await adapter.unsafeClearCachedRecords()
       const fetchedUpdatedRaw = await adapter.find('tasks', 't1')
       // eslint-disable-next-line
       expect(fetchedUpdatedRaw.bool1 == true).toEqual(true)
+      expect(fetchedUpdatedRaw.order == 2).toEqual(true)
       expect(fetchedUpdatedRaw).toEqual(record._raw)
       expect(fetchedUpdatedRaw).not.toBe(record._raw)
     },
@@ -253,8 +259,8 @@ export default () => [
   [
     'can get deleted record ids',
     adapter => async () => {
-      const m1 = makeMockTask({ id: 't1', text1: 'bar1' })
-      const m2 = makeMockTask({ id: 't2', text1: 'bar2' })
+      const m1 = makeMockTask({ id: 't1', text1: 'bar1', order: 1 })
+      const m2 = makeMockTask({ id: 't2', text1: 'bar2', order: 2 })
       await adapter.batch([
         ['create', m1],
         ['markAsDeleted', m1],
@@ -268,9 +274,9 @@ export default () => [
   [
     'can destroy deleted records',
     adapter => async () => {
-      const m1 = makeMockTask({ id: 't1', text1: 'bar1' })
-      const m2 = makeMockTask({ id: 't2', text1: 'bar2' })
-      const m3 = makeMockTask({ id: 't3', text1: 'bar3' })
+      const m1 = makeMockTask({ id: 't1', text1: 'bar1', order: 1 })
+      const m2 = makeMockTask({ id: 't2', text1: 'bar2', order: 2 })
+      const m3 = makeMockTask({ id: 't3', text1: 'bar3', order: 3 })
       await adapter.batch([
         ['create', m1],
         ['create', m2],
@@ -291,9 +297,9 @@ export default () => [
     adapter => async () => {
       const queryAll = () => adapter.query(taskQuery())
 
-      const m1 = makeMockTask({ id: 't1', text1: 'bar1' })
-      const m2 = makeMockTask({ id: 't2', text1: 'bar2' })
-      const m3 = makeMockTask({ id: 't3', text1: 'bar3' })
+      const m1 = makeMockTask({ id: 't1', text1: 'bar1', order: 1 })
+      const m2 = makeMockTask({ id: 't2', text1: 'bar2', order: 2})
+      const m3 = makeMockTask({ id: 't3', text1: 'bar3', order: 3 })
 
       await adapter.batch([
         ['create', m1],
@@ -323,12 +329,12 @@ export default () => [
   [
     'can unsafely reset database',
     adapter => async () => {
-      await adapter.batch([['create', makeMockTask({ id: 't1', text1: 'bar' })]])
+      await adapter.batch([['create', makeMockTask({ id: 't1', text1: 'bar', order: 1 })]])
       await adapter.unsafeResetDatabase()
       await expect(await adapter.count(taskQuery())).toBe(0)
 
       // check that reset database still works
-      await adapter.batch([['create', makeMockTask({ id: 't2', text1: 'baz' })]])
+      await adapter.batch([['create', makeMockTask({ id: 't2', text1: 'baz', order: 2 })]])
       expect(await adapter.count(taskQuery())).toBe(1)
     },
   ],
@@ -378,6 +384,11 @@ export default () => [
       // can be safely reassigned
       await adapter.setLocal('test1', 'val3')
       expect(await adapter.getLocal('test1')).toBe('val3')
+
+      // can use keywords as keys
+      // can be safely reassigned
+      await adapter.setLocal('order', '3')
+      expect(await adapter.getLocal('order')).toBe('3')
 
       // deleting already undefined is safe
       await adapter.removeLocal('nonexisting')

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -34,7 +34,7 @@ export default () => [
   [
     'can create and find records (sanity test)',
     adapter => async () => {
-      const record = makeMockTask({ id: 'abc', text1: 'bar' })
+      const record = makeMockTask({ id: 'abc', text1: 'bar', order: 1 })
       await adapter.batch([['create', record]])
       expect(await adapter.find('tasks', 'abc')).toBe('abc')
     },
@@ -43,8 +43,8 @@ export default () => [
     'can find single records',
     adapter => async () => {
       // side-add records
-      const s1 = makeMockTask({ id: 's1', text1: 'bar' })
-      const s2 = makeMockTask({ id: 's2', bool1: true })
+      const s1 = makeMockTask({ id: 's1', text1: 'bar', order: 1 })
+      const s2 = makeMockTask({ id: 's2', bool1: true, order: 2 })
       await adapter.batch([['create', s1], ['create', s2]])
       await adapter.unsafeClearCachedRecords()
 
@@ -86,9 +86,9 @@ export default () => [
   [
     'can query and count records',
     adapter => async () => {
-      const record1 = makeMockTask({ id: 't1', text1: 'bar', bool1: false })
-      const record2 = makeMockTask({ id: 't2', text1: 'baz', bool1: true })
-      const record3 = makeMockTask({ id: 't3', text1: 'abc', bool1: false })
+      const record1 = makeMockTask({ id: 't1', text1: 'bar', bool1: false, order: 1 })
+      const record2 = makeMockTask({ id: 't2', text1: 'baz', bool1: true, order: 2 })
+      const record3 = makeMockTask({ id: 't3', text1: 'abc', bool1: false, order: 3 })
 
       await adapter.batch([['create', record1], ['create', record2], ['create', record3]])
 
@@ -111,8 +111,8 @@ export default () => [
       const queryAll = () => adapter.query(taskQuery())
 
       // side-add records
-      const s1 = makeMockTask({ id: 's1' })
-      const s2 = makeMockTask({ id: 's2' })
+      const s1 = makeMockTask({ id: 's1', order: 1 })
+      const s2 = makeMockTask({ id: 's2', order: 2 })
       await adapter.batch([['create', s1]])
       await adapter.batch([['create', s2]])
       await adapter.unsafeClearCachedRecords()
@@ -149,8 +149,8 @@ export default () => [
     'sanitizes records on query',
     adapter => async () => {
       // Unsanitized raw!
-      const t1 = new MockTask({ table: 'tasks' }, { id: 't1', text1: 'foo' })
-      const t2 = new MockTask({ table: 'tasks' }, { id: 't2', text2: 'bar' })
+      const t1 = new MockTask({ table: 'tasks' }, { id: 't1', text1: 'foo', order: 1 })
+      const t2 = new MockTask({ table: 'tasks' }, { id: 't2', text2: 'bar', order: 2 })
       expect(t1._raw._status).toBeUndefined()
       expect(t2._raw._status).toBeUndefined()
 

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -251,6 +251,7 @@ export default () => [
       const fetchedUpdatedRaw = await adapter.find('tasks', 't1')
       // eslint-disable-next-line
       expect(fetchedUpdatedRaw.bool1 == true).toEqual(true)
+      // eslint-disable-next-line
       expect(fetchedUpdatedRaw.order == 2).toEqual(true)
       expect(fetchedUpdatedRaw).toEqual(record._raw)
       expect(fetchedUpdatedRaw).not.toBe(record._raw)
@@ -298,7 +299,7 @@ export default () => [
       const queryAll = () => adapter.query(taskQuery())
 
       const m1 = makeMockTask({ id: 't1', text1: 'bar1', order: 1 })
-      const m2 = makeMockTask({ id: 't2', text1: 'bar2', order: 2})
+      const m2 = makeMockTask({ id: 't2', text1: 'bar2', order: 2 })
       const m3 = makeMockTask({ id: 't3', text1: 'bar3', order: 3 })
 
       await adapter.batch([

--- a/src/adapters/__tests__/helpers.js
+++ b/src/adapters/__tests__/helpers.js
@@ -52,8 +52,8 @@ export const testSchema = appSchema({
         { name: 'text2', type: 'string' },
         { name: 'bool1', type: 'bool' },
         { name: 'bool2', type: 'bool' },
-        { name: 'order', type: 'number'},
-        { name: 'from', type: 'string'},
+        { name: 'order', type: 'number' },
+        { name: 'from', type: 'string' },
       ],
     }),
     tableSchema({

--- a/src/adapters/__tests__/helpers.js
+++ b/src/adapters/__tests__/helpers.js
@@ -52,6 +52,8 @@ export const testSchema = appSchema({
         { name: 'text2', type: 'string' },
         { name: 'bool1', type: 'bool' },
         { name: 'bool2', type: 'bool' },
+        { name: 'order', type: 'number'},
+        { name: 'from', type: 'string'},
       ],
     }),
     tableSchema({

--- a/src/adapters/sqlite/encodeInsert/index.js
+++ b/src/adapters/sqlite/encodeInsert/index.js
@@ -5,8 +5,11 @@ import { pipe, join, keys, values, always, map } from 'rambdax'
 import type Model from 'Model'
 import type { SQLiteQuery } from '../index'
 
+import encodeName from '../encodeName'
+
 const columnNames = pipe(
   keys,
+  map(encodeName),
   join(', '),
 )
 

--- a/src/adapters/sqlite/encodeInsert/test.js
+++ b/src/adapters/sqlite/encodeInsert/test.js
@@ -13,7 +13,7 @@ describe('watermelondb/adapters/sqlite/encodeInsert', () => {
       },
     }
     expect(encodeInsert(mockModel)).toEqual([
-      `insert into tasks (id, project_id, flag1, flag2, optional_attribute) values (?, ?, ?, ?, ?)`,
+      `insert into tasks ("id", "project_id", "flag1", "flag2", "optional_attribute") values (?, ?, ?, ?, ?)`,
       ['abcdef', '12345', true, false, null],
     ])
   })

--- a/src/adapters/sqlite/encodeName/index.js
+++ b/src/adapters/sqlite/encodeName/index.js
@@ -1,0 +1,5 @@
+// @flow
+
+export default function encodeName(name: string): string {
+  return `"${name}"`
+}

--- a/src/adapters/sqlite/encodeName/test.js
+++ b/src/adapters/sqlite/encodeName/test.js
@@ -1,0 +1,8 @@
+import encodeName from '.'
+
+describe('watermelondb/adapters/sqlite/encodeName', () => {
+  it('encodes names', () => {
+    expect(encodeName(`from`)).toBe(`"from"`)
+    expect(encodeName(`tasks`)).toBe(`"tasks"`)
+  })
+})

--- a/src/adapters/sqlite/encodeQuery/index.js
+++ b/src/adapters/sqlite/encodeQuery/index.js
@@ -130,8 +130,8 @@ const encodeMethod = (
 ): string => {
   if (countMode) {
     return needsDistinct ?
-      `select count(distinct ${encodeName(table)}."id") as count from ${encodeName(table)}` :
-      `select count(*) as count from ${encodeName(table)}`
+      `select count(distinct ${encodeName(table)}."id") as "count" from ${encodeName(table)}` :
+      `select count(*) as "count" from ${encodeName(table)}`
   }
 
   return needsDistinct ?

--- a/src/adapters/sqlite/encodeQuery/index.js
+++ b/src/adapters/sqlite/encodeQuery/index.js
@@ -18,6 +18,7 @@ import { type TableName, type ColumnName } from 'Schema'
 import type Model from 'Model'
 
 import encodeValue from '../encodeValue'
+import encodeName from '../encodeName'
 
 function mapJoin<T>(array: T[], mapper: T => string, joiner: string): string {
   return array.reduce(
@@ -36,7 +37,7 @@ const getComparisonRight = (table: TableName<any>, comparisonRight: ComparisonRi
   if (comparisonRight.values) {
     return encodeValues(comparisonRight.values)
   } else if (comparisonRight.column) {
-    return `${table}.${comparisonRight.column}`
+    return `${encodeName(table)}.${encodeName(comparisonRight.column)}`
   }
 
   return typeof comparisonRight.value !== 'undefined' ? encodeValue(comparisonRight.value) : 'null'
@@ -94,7 +95,7 @@ const encodeWhereCondition = (
     )
   }
 
-  return `${table}.${left} ${encodeComparison(table, comparison)}`
+  return `${encodeName(table)}.${encodeName(left)} ${encodeComparison(table, comparison)}`
 }
 
 const encodeAndOr = (op: string, table: TableName<any>, andOr: And | Or) => {
@@ -129,13 +130,13 @@ const encodeMethod = (
 ): string => {
   if (countMode) {
     return needsDistinct ?
-      `select count(distinct ${table}.id) as count from ${table}` :
-      `select count(*) as count from ${table}`
+      `select count(distinct ${encodeName(table)}."id") as count from ${encodeName(table)}` :
+      `select count(*) as count from ${encodeName(table)}`
   }
 
   return needsDistinct ?
-    `select distinct ${table}.* from ${table}` :
-    `select ${table}.* from ${table}`
+    `select distinct ${encodeName(table)}.* from ${encodeName(table)}` :
+    `select ${encodeName(table)}.* from ${encodeName(table)}`
 }
 
 const encodeAssociation: (TableName<any>) => AssociationArgs => string = mainTable => ([
@@ -143,8 +144,12 @@ const encodeAssociation: (TableName<any>) => AssociationArgs => string = mainTab
   association,
 ]) =>
   association.type === 'belongs_to' ?
-    ` join ${joinedTable} on ${joinedTable}.id = ${mainTable}.${association.key}` :
-    ` join ${joinedTable} on ${joinedTable}.${association.foreignKey} = ${mainTable}.id`
+    ` join ${encodeName(joinedTable)} on ${encodeName(joinedTable)}."id" = ${encodeName(
+        mainTable,
+      )}.${encodeName(association.key)}` :
+    ` join ${encodeName(joinedTable)} on ${encodeName(joinedTable)}.${encodeName(
+        association.foreignKey,
+      )} = ${encodeName(mainTable)}."id"`
 
 const encodeJoin = (table: TableName<any>, associations: AssociationArgs[]): string =>
   associations.length ? mapConcat(associations, encodeAssociation(table)) : ''

--- a/src/adapters/sqlite/encodeQuery/test.js
+++ b/src/adapters/sqlite/encodeQuery/test.js
@@ -76,7 +76,7 @@ describe('watermelondb/adapters/sqlite/encodeQuery', () => {
     const query = new Query(mockCollection, [Q.where('col1', 'value')])
     const sql = encodeQuery(query, true)
     expect(sql).toBe(
-      `select count(*) as count from "tasks" where "tasks"."col1" is 'value' and "tasks"."_status" is not 'deleted'`,
+      `select count(*) as "count" from "tasks" where "tasks"."col1" is 'value' and "tasks"."_status" is not 'deleted'`,
     )
   })
   it('encodes JOIN queries', () => {
@@ -90,7 +90,7 @@ describe('watermelondb/adapters/sqlite/encodeQuery', () => {
 
     expect(encodeQuery(query)).toBe(`select distinct "tasks".* from "tasks" ${expectedQuery}`)
     expect(encodeQuery(query, true)).toBe(
-      `select count(distinct "tasks"."id") as count from "tasks" ${expectedQuery}`,
+      `select count(distinct "tasks"."id") as "count" from "tasks" ${expectedQuery}`,
     )
   })
   it('encodes column comparisons on JOIN queries', () => {

--- a/src/adapters/sqlite/encodeQuery/test.js
+++ b/src/adapters/sqlite/encodeQuery/test.js
@@ -18,7 +18,7 @@ describe('watermelondb/adapters/sqlite/encodeQuery', () => {
   it('encodes simple queries', () => {
     const query = new Query(mockCollection, [])
     expect(encodeQuery(query)).toBe(
-      `select tasks.* from tasks where tasks._status is not 'deleted'`,
+      `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted'`,
     )
   })
   it('encodes multiple onditions and value types', () => {
@@ -30,7 +30,7 @@ describe('watermelondb/adapters/sqlite/encodeQuery', () => {
       Q.where('col5', null),
     ])
     expect(encodeQuery(query)).toBe(
-      `select tasks.* from tasks where tasks.col1 is 'value "''with''" quotes' and tasks.col2 is 2 and tasks.col3 is 1 and tasks.col4 is 0 and tasks.col5 is null and tasks._status is not 'deleted'`,
+      `select "tasks".* from "tasks" where "tasks"."col1" is 'value "''with''" quotes' and "tasks"."col2" is 2 and "tasks"."col3" is 1 and "tasks"."col4" is 0 and "tasks"."col5" is null and "tasks"."_status" is not 'deleted'`,
     )
   })
   it('encodes multiple operators', () => {
@@ -47,7 +47,7 @@ describe('watermelondb/adapters/sqlite/encodeQuery', () => {
       Q.where('col9', Q.between(10, 11)),
     ])
     expect(encodeQuery(query)).toBe(
-      `select tasks.* from tasks where tasks.col1 is 'val1' and tasks.col2 > 2 and tasks.col3 >= 3 and tasks.col3_5 > 3.5 and tasks.col4 < 4 and tasks.col5 <= 5 and tasks.col6 is not null and tasks.col7 in (1, 2, 3) and tasks.col8 not in ('"a"', '''b''', 'c') and tasks.col9 between 10 and 11 and tasks._status is not 'deleted'`,
+      `select "tasks".* from "tasks" where "tasks"."col1" is 'val1' and "tasks"."col2" > 2 and "tasks"."col3" >= 3 and "tasks"."col3_5" > 3.5 and "tasks"."col4" < 4 and "tasks"."col5" <= 5 and "tasks"."col6" is not null and "tasks"."col7" in (1, 2, 3) and "tasks"."col8" not in ('"a"', '''b''', 'c') and "tasks"."col9" between 10 and 11 and "tasks"."_status" is not 'deleted'`,
     )
   })
   it('encodes column comparisons', () => {
@@ -56,7 +56,7 @@ describe('watermelondb/adapters/sqlite/encodeQuery', () => {
       Q.where('left2', Q.weakGt(Q.column('right2'))),
     ])
     expect(encodeQuery(query)).toBe(
-      `select tasks.* from tasks where tasks.left1 >= tasks.right1 and (tasks.left2 > tasks.right2 or (tasks.left2 is not null and tasks.right2 is null)) and tasks._status is not 'deleted'`,
+      `select "tasks".* from "tasks" where "tasks"."left1" >= "tasks"."right1" and ("tasks"."left2" > "tasks"."right2" or ("tasks"."left2" is not null and "tasks"."right2" is null)) and "tasks"."_status" is not 'deleted'`,
     )
   })
   it('encodes AND/OR nesting', () => {
@@ -69,14 +69,14 @@ describe('watermelondb/adapters/sqlite/encodeQuery', () => {
       ),
     ])
     expect(encodeQuery(query)).toBe(
-      `select tasks.* from tasks where tasks.col1 is 'value' and (tasks.col2 is 1 or tasks.col3 is null or (tasks.col4 > 5 and tasks.col5 not in (6, 7))) and tasks._status is not 'deleted'`,
+      `select "tasks".* from "tasks" where "tasks"."col1" is 'value' and ("tasks"."col2" is 1 or "tasks"."col3" is null or ("tasks"."col4" > 5 and "tasks"."col5" not in (6, 7))) and "tasks"."_status" is not 'deleted'`,
     )
   })
   it('encodes count queries', () => {
     const query = new Query(mockCollection, [Q.where('col1', 'value')])
     const sql = encodeQuery(query, true)
     expect(sql).toBe(
-      `select count(*) as count from tasks where tasks.col1 is 'value' and tasks._status is not 'deleted'`,
+      `select count(*) as count from "tasks" where "tasks"."col1" is 'value' and "tasks"."_status" is not 'deleted'`,
     )
   })
   it('encodes JOIN queries', () => {
@@ -86,11 +86,11 @@ describe('watermelondb/adapters/sqlite/encodeQuery', () => {
       Q.where('left_column', 'right_value'),
       Q.on('tag_assignments', 'tag_id', Q.oneOf(['a', 'b', 'c'])),
     ])
-    const expectedQuery = `join projects on projects.id = tasks.project_id join tag_assignments on tag_assignments.task_id = tasks.id where projects.team_id is 'abcdef' and projects.is_active is 1 and tag_assignments.tag_id in ('a', 'b', 'c') and projects._status is not 'deleted' and tag_assignments._status is not 'deleted' and tasks.left_column is 'right_value' and tasks._status is not 'deleted'`
+    const expectedQuery = `join "projects" on "projects"."id" = "tasks"."project_id" join "tag_assignments" on "tag_assignments"."task_id" = "tasks"."id" where "projects"."team_id" is 'abcdef' and "projects"."is_active" is 1 and "tag_assignments"."tag_id" in ('a', 'b', 'c') and "projects"."_status" is not 'deleted' and "tag_assignments"."_status" is not 'deleted' and "tasks"."left_column" is 'right_value' and "tasks"."_status" is not 'deleted'`
 
-    expect(encodeQuery(query)).toBe(`select distinct tasks.* from tasks ${expectedQuery}`)
+    expect(encodeQuery(query)).toBe(`select distinct "tasks".* from "tasks" ${expectedQuery}`)
     expect(encodeQuery(query, true)).toBe(
-      `select count(distinct tasks.id) as count from tasks ${expectedQuery}`,
+      `select count(distinct "tasks"."id") as count from "tasks" ${expectedQuery}`,
     )
   })
   it('encodes column comparisons on JOIN queries', () => {
@@ -99,7 +99,7 @@ describe('watermelondb/adapters/sqlite/encodeQuery', () => {
       Q.on('projects', 'left2', Q.weakGt(Q.column('right2'))),
     ])
     expect(encodeQuery(query)).toBe(
-      `select tasks.* from tasks join projects on projects.id = tasks.project_id where projects.left_column <= projects.right_column and (projects.left2 > projects.right2 or (projects.left2 is not null and projects.right2 is null)) and projects._status is not 'deleted' and tasks._status is not 'deleted'`,
+      `select "tasks".* from "tasks" join "projects" on "projects"."id" = "tasks"."project_id" where "projects"."left_column" <= "projects"."right_column" and ("projects"."left2" > "projects"."right2" or ("projects"."left2" is not null and "projects"."right2" is null)) and "projects"."_status" is not 'deleted' and "tasks"."_status" is not 'deleted'`,
     )
   })
 })

--- a/src/adapters/sqlite/encodeSchema/index.js
+++ b/src/adapters/sqlite/encodeSchema/index.js
@@ -4,18 +4,27 @@ import { keys, values } from 'rambdax'
 import type { TableSchema, AppSchema } from 'Schema'
 import type { SQL } from '../index'
 
-const standardColumns = `_changed, _status, id primary key, last_modified`
+import encodeName from '../encodeName'
+
+const standardColumns = `"_changed", "_status", "id" primary key, "last_modified"`
 
 const encodeCreateTable: TableSchema => SQL = ({ name, columns }) => {
-  const columnsSQL = [standardColumns].concat(keys(columns)).join(', ')
-  return `create table ${name} (${columnsSQL});`
+  const columnsSQL = [standardColumns]
+    .concat(keys(columns).map(column => encodeName(column)))
+    .join(', ')
+  return `create table ${encodeName(name)} (${columnsSQL});`
 }
 
 const encodeTableIndicies: TableSchema => SQL = ({ name: tableName, columns }) =>
   values(columns)
     .filter(column => column.isIndexed)
-    .map(column => `create index ${tableName}_${column.name} on ${tableName} (${column.name})`)
-    .concat([`create index ${tableName}__status on ${tableName} (_status)`])
+    .map(
+      column =>
+        `create index ${tableName}_${column.name} on ${encodeName(tableName)} (${encodeName(
+          column.name,
+        )})`,
+    )
+    .concat([`create index ${tableName}__status on ${encodeName(tableName)} ("_status")`])
     .join(';')
 
 const encodeTable: TableSchema => SQL = table =>

--- a/src/adapters/sqlite/encodeSchema/test.js
+++ b/src/adapters/sqlite/encodeSchema/test.js
@@ -21,12 +21,12 @@ const testSchema = appSchema({
 })
 
 const expectedSchema =
-  'create table tasks (_changed, _status, id primary key, last_modified, author_id, position, created_at);' +
-  'create index tasks_author_id on tasks (author_id);' +
-  'create index tasks_position on tasks (position);' +
-  'create index tasks__status on tasks (_status);' +
-  'create table comments (_changed, _status, id primary key, last_modified, is_ended, reactions);' +
-  'create index comments__status on comments (_status);'
+  'create table "tasks" ("_changed", "_status", "id" primary key, "last_modified", "author_id", "position", "created_at");' +
+  'create index tasks_author_id on "tasks" ("author_id");' +
+  'create index tasks_position on "tasks" ("position");' +
+  'create index tasks__status on "tasks" ("_status");' +
+  'create table "comments" ("_changed", "_status", "id" primary key, "last_modified", "is_ended", "reactions");' +
+  'create index comments__status on "comments" ("_status");'
 
 describe('watermelondb/adapters/sqlite/encodeSchema', () => {
   it('encodes schema', () => {

--- a/src/adapters/sqlite/encodeSchema/test.js
+++ b/src/adapters/sqlite/encodeSchema/test.js
@@ -9,7 +9,7 @@ const testSchema = appSchema({
       name: 'tasks',
       columns: [
         { name: 'author_id', type: 'string', isIndexed: true },
-        { name: 'position', type: 'number', isOptional: true, isIndexed: true },
+        { name: 'order', type: 'number', isOptional: true, isIndexed: true },
         { name: 'created_at', type: 'number' },
       ],
     }),
@@ -21,9 +21,9 @@ const testSchema = appSchema({
 })
 
 const expectedSchema =
-  'create table "tasks" ("_changed", "_status", "id" primary key, "last_modified", "author_id", "position", "created_at");' +
+  'create table "tasks" ("_changed", "_status", "id" primary key, "last_modified", "author_id", "order", "created_at");' +
   'create index tasks_author_id on "tasks" ("author_id");' +
-  'create index tasks_position on "tasks" ("position");' +
+  'create index tasks_order on "tasks" ("order");' +
   'create index tasks__status on "tasks" ("_status");' +
   'create table "comments" ("_changed", "_status", "id" primary key, "last_modified", "is_ended", "reactions");' +
   'create index comments__status on "comments" ("_status");'

--- a/src/adapters/sqlite/encodeUpdate/index.js
+++ b/src/adapters/sqlite/encodeUpdate/index.js
@@ -6,8 +6,11 @@ import type Model from 'Model'
 import { type RawRecord } from 'RawRecord'
 import type { SQL, SQLiteQuery, SQLiteArg } from '../index'
 
+import encodeName from '../encodeName'
+
 const encodeSetPlaceholders: RawRecord => SQL = pipe(
   keys,
+  map(encodeName),
   map(key => `${key}=?`),
   join(', '),
 )
@@ -20,7 +23,7 @@ const getArgs: RawRecord => SQLiteArg[] = raw =>
 
 export default function encodeUpdate(model: Model): SQLiteQuery {
   const { _raw: raw, table } = model
-  const sql = `update ${table} set ${encodeSetPlaceholders(raw)} where id is ?`
+  const sql = `update ${encodeName(table)} set ${encodeSetPlaceholders(raw)} where "id" is ?`
   const args = getArgs(raw)
 
   return [sql, args]

--- a/src/adapters/sqlite/encodeUpdate/test.js
+++ b/src/adapters/sqlite/encodeUpdate/test.js
@@ -13,7 +13,7 @@ describe('watermelondb/adapters/sqlite/encodeUpdate', () => {
       },
     }
     expect(encodeUpdate(mockModel)).toEqual([
-      `update tasks set id=?, project_id=?, flag1=?, flag2=?, optional_attribute=? where id is ?`,
+      `update "tasks" set "id"=?, "project_id"=?, "flag1"=?, "flag2"=?, "optional_attribute"=? where "id" is ?`,
       ['abcdef', '12345', true, false, null, 'abcdef'],
     ])
   })


### PR DESCRIPTION
@radex gave this a quick shot. Is there any way to integration-test this out-of-the-box? 

Fixes #9 