### PR TITLE
Don't rely on Jest to mock lokijs web worker in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Add quotes to all names in sql queries to allow keywords as table or column names
+- Fixed running model tests in apps with Watermelon in the loop
 
 ## [0.6.0] - 2018-09-05
 

--- a/__tests__/setup.js
+++ b/__tests__/setup.js
@@ -1,6 +1,3 @@
 import { logger } from 'utils/common'
 
 logger.silence()
-
-// Ensure Loki web worker mock is used
-jest.mock('adapters/lokijs/worker/index.worker')

--- a/scripts/make.js
+++ b/scripts/make.js
@@ -216,6 +216,7 @@ if (isDevelopment) {
     'native/android',
     'babel',
   ])
+  cleanFolder(`${DIST_PATH}/native/android/build`)
   copyFiles(DIST_PATH, modules, SOURCE_PATH)
   buildCjsPathMapping(modules)
   buildEsmPathMapping(modules)

--- a/scripts/make.js
+++ b/scripts/make.js
@@ -207,7 +207,15 @@ if (isDevelopment) {
   cleanFolder(DIST_PATH)
   createFolder(DIST_PATH)
   createPackageJson(DIST_PATH, pkg)
-  copyFiles(DIST_PATH, ['LICENSE', 'README.md', 'yarn.lock', 'docs', 'native', 'babel'])
+  copyFiles(DIST_PATH, [
+    'LICENSE',
+    'README.md',
+    'yarn.lock',
+    'docs',
+    'native/ios',
+    'native/android',
+    'babel',
+  ])
   copyFiles(DIST_PATH, modules, SOURCE_PATH)
   buildCjsPathMapping(modules)
   buildEsmPathMapping(modules)

--- a/src/adapters/lokijs/WorkerBridge.js
+++ b/src/adapters/lokijs/WorkerBridge.js
@@ -25,8 +25,7 @@ class WorkerBridge {
   _pendingRequests: WorkerActions = []
 
   _createWorker(): Worker {
-    const WorkerClass = (LokiWorker: any)
-    const worker: Worker = new WorkerClass()
+    const worker: Worker = (new LokiWorker(): any)
 
     worker.onmessage = ({ data }) => {
       const { type, payload }: WorkerResponseAction = (data: any)

--- a/src/adapters/lokijs/WorkerBridge.js
+++ b/src/adapters/lokijs/WorkerBridge.js
@@ -25,7 +25,8 @@ class WorkerBridge {
   _pendingRequests: WorkerActions = []
 
   _createWorker(): Worker {
-    const worker: Worker = new LokiWorker()
+    const WorkerClass = (LokiWorker: any)
+    const worker: Worker = new WorkerClass()
 
     worker.onmessage = ({ data }) => {
       const { type, payload }: WorkerResponseAction = (data: any)

--- a/src/adapters/lokijs/worker/index.worker.js
+++ b/src/adapters/lokijs/worker/index.worker.js
@@ -5,18 +5,17 @@
 
 import LokiWorker from './lokiWorker'
 
-let defaultExport
-
 // In a web browser, Webpack will spin up a web worker and run this code there, while the importing
 // module will see a Worker class.
 // But Jest will actually import this file and has to provide a Worker interface, so we export a mock
+const getDefaultExport = () => {
+  if (process.env.NODE_ENV === 'test') {
+    const workerMock = require('./workerMock').default
+    return workerMock
+  }
 
-if (process.env.NODE_ENV === 'test') {
-  const workerMock = require('./workerMock').default
-  defaultExport = workerMock
-} else {
   self.workerClass = new LokiWorker(self)
-  defaultExport = self
+  return self
 }
 
-export default defaultExport
+export default getDefaultExport()

--- a/src/adapters/lokijs/worker/index.worker.js
+++ b/src/adapters/lokijs/worker/index.worker.js
@@ -1,7 +1,6 @@
 // @flow
 /* eslint-disable no-restricted-globals */
 /* eslint-disable global-require */
-/* eslint-disable import/no-mutable-exports */
 
 import LokiWorker from './lokiWorker'
 

--- a/src/adapters/lokijs/worker/index.worker.js
+++ b/src/adapters/lokijs/worker/index.worker.js
@@ -1,10 +1,22 @@
 // @flow
 /* eslint-disable no-restricted-globals */
+/* eslint-disable global-require */
+/* eslint-disable import/no-mutable-exports */
 
 import LokiWorker from './lokiWorker'
 
-if (process.env.NODE_ENV !== 'test') {
+let defaultExport
+
+// In a web browser, Webpack will spin up a web worker and run this code there, while the importing
+// module will see a Worker class.
+// But Jest will actually import this file and has to provide a Worker interface, so we export a mock
+
+if (process.env.NODE_ENV === 'test') {
+  const workerMock = require('./workerMock').default
+  defaultExport = workerMock
+} else {
   self.workerClass = new LokiWorker(self)
+  defaultExport = self
 }
 
-export default self
+export default defaultExport

--- a/src/adapters/lokijs/worker/workerMock.js
+++ b/src/adapters/lokijs/worker/workerMock.js
@@ -1,7 +1,7 @@
 // @flow
 
 import clone from 'lodash.clonedeep'
-import LokiWorker from '../lokiWorker'
+import LokiWorker from './lokiWorker'
 
 // Simulates the web worker API for test env (while really just passing messages asynchronously
 // on main thread)


### PR DESCRIPTION
- This fixes Purple tests. Before, Jest magic was required to use a web worker mock in tests. Now, it's just NODE_ENV check and conditional require, so it works in Purple out of the box
- Improves build script (doesn't copy over unnecessary native files)