### PR TITLE
Fix Flow in apps using WatermelonDB

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -71,12 +71,12 @@ module.exports = {
     },
     rewriteonly: {
       plugins: [
-        '@babel/plugin-syntax-flow',
         '@babel/plugin-syntax-class-properties',
         ['@babel/plugin-syntax-decorators', { legacy: true }],
-        '@babel/plugin-syntax-jsx',
+        // '@babel/plugin-syntax-jsx',
         '@babel/plugin-syntax-object-rest-spread',
         '@babel/plugin-syntax-optional-chaining',
+        '@babel/plugin-syntax-flow',
         ...modules,
       ],
     },

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -41,12 +41,12 @@ const modules = [
       root: ['./src'],
     },
   ],
-  [
-    'babel-plugin-root-import',
-    {
-      rootPathSuffix: './src',
-    },
-  ],
+  // [
+  //   'babel-plugin-root-import',
+  //   {
+  //     rootPathSuffix: './src',
+  //   },
+  // ],
 ]
 
 module.exports = {
@@ -68,6 +68,17 @@ module.exports = {
     },
     test: {
       plugins: ['@babel/plugin-transform-modules-commonjs', ...plugins],
+    },
+    rewriteonly: {
+      plugins: [
+        '@babel/plugin-syntax-flow',
+        '@babel/plugin-syntax-class-properties',
+        ['@babel/plugin-syntax-decorators', { legacy: true }],
+        '@babel/plugin-syntax-jsx',
+        '@babel/plugin-syntax-object-rest-spread',
+        '@babel/plugin-syntax-optional-chaining',
+        ...modules,
+      ],
     },
   },
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Changed Flow setup for apps using Watermelon - see docs/Advanced/Flow.md
 
 ### Fixed
 - Add quotes to all names in sql queries to allow keywords as table or column names
 - Fixed running model tests in apps with Watermelon in the loop
+- Fixed Flow when using Watermelon in apps
 
 ## [0.6.0] - 2018-09-05
 

--- a/docs/Advanced/Flow.md
+++ b/docs/Advanced/Flow.md
@@ -4,6 +4,18 @@ Watermelon was developed with [Flow](https://flow.org) in mind.
 
 If you're a Flow user yourself (and we highly recommend it!), here's some things you need to keep in mind:
 
+## Setup
+
+Add to your `.flowconfig` file:
+
+```ini
+[options]
+
+module.name_mapper='^@nozbe/watermelondb\(.*\)$' -> '<PROJECT_ROOT>/node_modules/@nozbe/watermelondb/src\1'
+```
+
+Note that this won't work if you put the entire `node_modules/` folder under the `[ignore]` section. In that case, change it to only ignore the specific node modules that throw errors in your app, so that Flow can scan Watermelon files.
+
 ## Tables and columns
 
 Table and column names are **opaque types** in Flow.

--- a/docs/Advanced/Flow.md
+++ b/docs/Advanced/Flow.md
@@ -6,7 +6,7 @@ If you're a Flow user yourself (and we highly recommend it!), here's some things
 
 ## Setup
 
-Add to your `.flowconfig` file:
+Add this to your `.flowconfig` file so that Flow can see Watermelon's types.
 
 ```ini
 [options]

--- a/scripts/make.js
+++ b/scripts/make.js
@@ -44,7 +44,6 @@ const DIR_PATH = isDevelopment ? DEV_PATH : DIST_PATH
 const DO_NOT_BUILD_PATHS = [
   /adapters\/__tests__/,
   /test\.js/,
-  /type\.js/,
   /integrationTest\.js/,
   /__mocks__/,
   /\.DS_Store/,

--- a/src/Model/helpers.js
+++ b/src/Model/helpers.js
@@ -2,7 +2,7 @@
 
 import hasIn from 'utils/fp/hasIn'
 
-import type Model from '.'
+import type Model from './index'
 
 const hasCreatedAt = hasIn('createdAt')
 export const hasUpdatedAt = hasIn('updatedAt')

--- a/src/QueryDescription/index.js
+++ b/src/QueryDescription/index.js
@@ -186,9 +186,13 @@ export function or(...conditions: Where[]): Or {
   return { type: 'or', conditions }
 }
 
-type OnFunction = ((TableName<any>, ColumnName, Value) => On) &
-  ((TableName<any>, ColumnName, Comparison) => On) &
-  ((TableName<any>, WhereDescription) => On)
+// Note: we have to write out three separate meanings of OnFunction because of a Babel bug
+// (it will remove the parentheses, changing the meaning of the flow type)
+type _OnFunctionColumnValue = (TableName<any>, ColumnName, Value) => On
+type _OnFunctionColumnComparison = (TableName<any>, ColumnName, Comparison) => On
+type _OnFunctionWhereDescription = (TableName<any>, WhereDescription) => On
+
+type OnFunction = _OnFunctionColumnValue & _OnFunctionColumnComparison & _OnFunctionWhereDescription
 
 // Use: on('tableName', 'left_column', 'right_value')
 // or: on('tableName', 'left_column', gte(10))

--- a/src/Relation/index.js
+++ b/src/Relation/index.js
@@ -69,8 +69,7 @@ export default class Relation<T: ?Model> {
       return this._model.collections.get(this._relationTableName).find(id)
     }
 
-    // $FlowFixMe
-    return Promise.resolve(null)
+    return Promise.resolve((null: any))
   }
 
   set(record: T): void {

--- a/src/adapters/lokijs/worker/executeQuery.js
+++ b/src/adapters/lokijs/worker/executeQuery.js
@@ -21,8 +21,7 @@ function refineResultsForColumnComparisons(
     const matcher = encodeMatcher(queryWithoutJoins)
 
     // Workaround: encodeMatcher expects a Model so we wrap the raw in an { _raw:... } object
-    // $FlowFixMe
-    const lokiMatcher = raw => matcher({ _raw: raw })
+    const lokiMatcher = raw => matcher(({ _raw: raw }: any))
 
     return roughResults.where(lokiMatcher)
   }

--- a/src/adapters/lokijs/worker/lokiWorker.js
+++ b/src/adapters/lokijs/worker/lokiWorker.js
@@ -46,8 +46,8 @@ export default class LokiWorker {
     // https://github.com/facebook/flow/blob/master/lib/bom.js#L504
     // looks like incorrect type, should be: onmessage: (ev: MessageEvent) => any;
     // PR: https://github.com/facebook/flow/pull/6100
-    // $FlowFixMe
-    this.workerContext.onmessage = (e: MessageEvent) => {
+    const context = (this.workerContext: any)
+    context.onmessage = (e: MessageEvent) => {
       this.asyncQueue.push(e.data, (action: WorkerExecutorAction) => {
         const { type, payload } = action
 

--- a/src/observation/encodeMatcher/index.js
+++ b/src/observation/encodeMatcher/index.js
@@ -72,6 +72,5 @@ export default function encodeMatcher<Element: Model>(query: QueryDescription): 
 
   invariant(!join.length, `Queries with joins can't be encoded into a matcher`)
 
-  // $FlowFixMe
-  return encodeConditions(where)
+  return (encodeConditions(where): any)
 }


### PR DESCRIPTION
- Instead of copying 🍉 source files to the compiled NPM dist/ folder directly, it puts them in dist/src
- … but first runs Babel through those files to rewrite import paths to relative paths, since we use absolute paths and 3rd party apps have no idea what they mean.
- Unfortunately there's a Babel bug and the original comments in files are written wrong (there's often an empty line between a comment and the next line of code), so `// $FlowFixMe` wouldn't work. So I rewrote those to use `(x : any)`. Also fixed other issues that produced problems when running Flow in Purple
- added docs to explain how to use Flow in apps with Watermelon