### PR TITLE
Android Emulator Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "swiftlint": "cd native; swiftlint",
     "ktlint": "cd native/androidTest; ./gradlew ktlint",
     "ktlint:format": "cd native/androidTest; ./gradlew ktlintFormat",
-    "android:emulator": "node ./scripts/emulator.js"
+    "android:emulator": "export JAVA_OPTS=\"-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee\"; node ./scripts/emulator.js"
   },
   "author": "@Nozbe",
   "homepage": "https://github.com/Nozbe/WatermelonDB#readme",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "swiftlint": "cd native; swiftlint",
     "ktlint": "cd native/androidTest; ./gradlew ktlint",
     "ktlint:format": "cd native/androidTest; ./gradlew ktlintFormat",
-    "android:emulator": "export JAVA_OPTS=\"-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee\"; node ./scripts/emulator.js"
+    "android:emulator": "./scripts/emulatorWithJavaCheck"
   },
   "author": "@Nozbe",
   "homepage": "https://github.com/Nozbe/WatermelonDB#readme",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:ios": "cd native/iosTest; xcodebuild -workspace WatermelonTester.xcworkspace -scheme 'WatermelonTester' -destination 'name=iPhone 8' test",
     "swiftlint": "cd native; swiftlint",
     "ktlint": "cd native/androidTest; ./gradlew ktlint",
-    "ktlint:format": "cd native/androidTest; ./gradlew ktlintFormat"
+    "ktlint:format": "cd native/androidTest; ./gradlew ktlintFormat",
+    "android:emulator": "node ./scripts/emulator.js"
   },
   "author": "@Nozbe",
   "homepage": "https://github.com/Nozbe/WatermelonDB#readme",

--- a/scripts/emulator.js
+++ b/scripts/emulator.js
@@ -86,7 +86,6 @@ const emulatorTasks = options => {
           // eslint-disable-next-line
           console.log('Downloading Emulator Image\nIt may take a while')
           execSync('touch ~/.android/repositories.cfg')
-          execSync('export JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee"')
           execSync(`$ANDROID_HOME/tools/bin/sdkmanager "${sdkPath}"`)
         },
       })

--- a/scripts/emulator.js
+++ b/scripts/emulator.js
@@ -16,6 +16,7 @@ const askForEmu = [
     message: 'Pick Emulator from list or add a new one',
     choices: emulators
       .split('\n')
+      .filter(value => value.length > 0)
       .map(emu => ({
         name: emu,
         value: emu,

--- a/scripts/emulator.js
+++ b/scripts/emulator.js
@@ -46,17 +46,20 @@ const askForEmu = [
 
 const openEmu = options => {
   const { name, sdk } = options
-  if (sdk !== null) {
+  if (sdk !== undefined) {
     return [
       {
         title: 'create emu',
         task: () => {
           execSync('export JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee"')
           execSync(
-            `echo yes | $ANDROID_HOME/tools/bin/avdmanager create avd -n ${name.replace(
+            `echo no | $ANDROID_HOME/tools/bin/avdmanager create avd -n ${name.replace(
               /\s/g,
               '',
-            )} -k "system-images;android-${sdk.replace(/\s/g, '')};google_apis_playstore;x86"`,
+            )} -k "system-images;android-${sdk.replace(
+              /\s/g,
+              '',
+            )};google_apis;x86" --device "Nexus 6P"`,
           )
         },
       },
@@ -65,7 +68,7 @@ const openEmu = options => {
   return [
     {
       title: 'Open Emulator',
-      task: () => execSync(`$ANDROID_HOME/emulator/emulator`, [`@${name}`]),
+      task: () => execSync(`$ANDROID_HOME/emulator/emulator @${name}`),
     },
   ]
 }

--- a/scripts/emulator.js
+++ b/scripts/emulator.js
@@ -33,7 +33,7 @@ const askForEmu = [
     type: 'input',
     name: 'sdk',
     when: answers => !answers.name,
-    message: 'sdk number:',
+    message: 'Sdk Version (21-28):',
     validate: input => input > 20 && input < 29,
   },
   {
@@ -49,9 +49,22 @@ const openEmu = options => {
   if (sdk !== undefined) {
     return [
       {
-        title: 'create emu',
+        title: 'Downloading Emulator Image',
         task: () => {
+          console.log('Downloading Emulator Image\nIt may take a while')
+          execSync('touch ~/.android/repositories.cfg')
           execSync('export JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee"')
+          execSync(
+            `$ANDROID_HOME/tools/bin/sdkmanager "system-images;android-${sdk.replace(
+              /\s/g,
+              '',
+            )};google_apis;x86"`,
+          )
+        },
+      },
+      {
+        title: `Creating Emulator ${name}`,
+        task: () => {
           execSync(
             `echo no | $ANDROID_HOME/tools/bin/avdmanager create avd -n ${name.replace(
               /\s/g,

--- a/scripts/emulator.js
+++ b/scripts/emulator.js
@@ -7,6 +7,8 @@ const inquirer = require('inquirer')
 
 const { execSync } = require('child_process')
 
+const { add } = require('rambdax')
+
 const emulators = execSync(`$ANDROID_HOME/emulator/emulator -list-avds`).toString()
 const sdks = execSync(
   `$ANDROID_HOME/tools/bin/sdkmanager --list | grep "system-images/" `,
@@ -17,6 +19,7 @@ const askForEmu = [
     type: 'list',
     name: 'name',
     message: 'Pick Emulator from list or add a new one',
+    pageSize: add(emulators.length, 4),
     choices: emulators
       .split('\n')
       .filter(value => value.length > 0)
@@ -38,6 +41,7 @@ const askForEmu = [
     name: 'sdk',
     when: answers => !answers.name,
     message: 'Sdk Version:',
+    pageSize: add(sdks.length, 4),
     choices: sdks
       .split('\n')
       .filter(value => value.length > 0)
@@ -78,6 +82,7 @@ const openEmu = options => {
       {
         title: 'Downloading Emulator Image',
         task: () => {
+          // eslint-disable-next-line
           console.log('Downloading Emulator Image\nIt may take a while')
           execSync('touch ~/.android/repositories.cfg')
           execSync('export JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee"')

--- a/scripts/emulator.js
+++ b/scripts/emulator.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+// inspired by `np` – https://github.com/sindresorhus/np
+
+const Listr = require('listr')
+const inquirer = require('inquirer')
+
+const { execSync } = require('child_process')
+
+const emulators = execSync(`$ANDROID_HOME/emulator/emulator -list-avds`).toString()
+
+const askForEmu = [
+  {
+    type: 'list',
+    name: 'name',
+    message: 'Pick Emulator from list or add a new one',
+    choices: emulators
+      .split('\n')
+      .map(emu => ({
+        name: emu,
+        value: emu,
+      }))
+      .concat([
+        new inquirer.Separator(),
+        {
+          name: 'New Emu',
+          value: null,
+        },
+        new inquirer.Separator(),
+      ]),
+  },
+  {
+    type: 'input',
+    name: 'sdk',
+    when: answers => !answers.name,
+    message: 'sdk number:',
+    validate: input => input > 20 && input < 29,
+  },
+  {
+    type: 'input',
+    name: 'name',
+    when: answers => !answers.name,
+    message: 'Name:',
+  },
+]
+
+const openEmu = options => {
+  const { name, sdk } = options
+  if (sdk !== null) {
+    return [
+      {
+        title: 'create emu',
+        task: () => {
+          execSync('export JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee"')
+          execSync(
+            `echo yes | $ANDROID_HOME/tools/bin/avdmanager create avd -n ${name.replace(
+              /\s/g,
+              '',
+            )} -k "system-images;android-${sdk.replace(/\s/g, '')};google_apis_playstore;x86"`,
+          )
+        },
+      },
+    ]
+  }
+  return [
+    {
+      title: 'Open Emulator',
+      task: () => execSync(`$ANDROID_HOME/emulator/emulator`, [`@${name}`]),
+    },
+  ]
+}
+inquirer.prompt(askForEmu).then(options => {
+  const tasks = openEmu(options)
+  const listr = new Listr(tasks)
+  listr.run()
+})

--- a/scripts/emulatorWithJavaCheck
+++ b/scripts/emulatorWithJavaCheck
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if javac --version | grep -q '10.0'; then
+  export JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee"
+fi
+if javac --version | grep -q '1.9'; then
+  export JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee"
+fi
+  node ./scripts/emulator.js

--- a/scripts/emulatorWithJavaCheck
+++ b/scripts/emulatorWithJavaCheck
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if javac --version | grep -q '10.0'; then
+if javac -version | grep -q '10.0'; then
   export JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee"
 fi
-if javac --version | grep -q '1.9'; then
+if javac -version | grep -q '1.9'; then
   export JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee"
 fi
   node ./scripts/emulator.js


### PR DESCRIPTION
Script for starting/creating new Android emulator.

You can start it by `npm run android:emulator` or `yarn android:emulator`

Options:
 - Run one of the existing emulators
 - Create new emulator using already installed system image
 - Download new system image and then create new Emulator

Every emulator created by this script is based on Nexus 6P (1440x2560px (5.70")) to simplify configuration process.

**Android Studio is still required!**

`export JAVA_OPTS="-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee"` is needed because of [a bug with Java 1.9+](https://stackoverflow.com/questions/46402772/failed-to-install-android-sdk-java-lang-noclassdeffounderror-javax-xml-bind-a)