### PR TITLE
Adapter testing refactoring

### DIFF
--- a/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
@@ -14,7 +14,6 @@ class Database(private val name: String?, private val context: Context) {
         SQLiteDatabase.openOrCreateDatabase(
                 context.getDatabasePath("$name.db").path
                         .replace("/databases", ""), null)
-
     }
 
     var userVersion: Int

--- a/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
@@ -10,14 +10,11 @@ class Database(private val name: String?, private val context: Context) {
     private val log = if (BuildConfig.DEBUG) Logger.getLogger("Database") else null
 
     private val db: SQLiteDatabase by lazy {
-        if (name.isNullOrBlank() || name == "test") {
-            SQLiteDatabase.create(null)
-        } else {
-            // On some systems there is some kind of lock on `/databases` folder ¯\_(ツ)_/¯
-            SQLiteDatabase.openOrCreateDatabase(
-                    context.getDatabasePath("$name.db").path
-                            .replace("/databases", ""), null)
-        }
+        // On some systems there is some kind of lock on `/databases` folder ¯\_(ツ)_/¯
+        SQLiteDatabase.openOrCreateDatabase(
+                context.getDatabasePath("$name.db").path
+                        .replace("/databases", ""), null)
+
     }
 
     var userVersion: Int

--- a/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
@@ -71,10 +71,6 @@ class DatabaseBridge(private val reactContext: ReactApplicationContext) :
             connections[tag]?.doWithPromise(promise) { it.unsafeResetDatabase() }
 
     @ReactMethod
-    fun unsafeClearCachedRecords(tag: ConnectionTag, promise: Promise) =
-            connections[tag]?.doWithPromise(promise) { it.unsafeClearCachedRecords() }
-
-    @ReactMethod
     fun getLocal(tag: ConnectionTag, key: String, promise: Promise) =
             connections[tag]?.doWithPromise(promise) { it.getLocal(key) }
 

--- a/native/android/src/main/java/com/nozbe/watermelondb/DatabaseDriver.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/DatabaseDriver.kt
@@ -76,10 +76,6 @@ class DatabaseDriver(context: Context, private val configuration: Configuration)
         return resultArray
     }
 
-    fun unsafeClearCachedRecords() {
-        cachedRecords = arrayListOf()
-    }
-
     fun destroyDeletedRecords(table: TableName, records: QueryArgs) =
             database.delete(Queries.multipleDeleteFromTable(table, records), records)
 

--- a/native/androidTest/app/src/main/AndroidManifest.xml
+++ b/native/androidTest/app/src/main/AndroidManifest.xml
@@ -1,9 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.nozbe.watermelonTest">
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
       android:name=".MainApplication"
-      android:label="@string/app_name">
+      android:label="@string/app_name"
+        tools:ignore="GoogleAppIndexingWarning">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/native/ios/WatermelonDB/Database.swift
+++ b/native/ios/WatermelonDB/Database.swift
@@ -29,6 +29,13 @@ class Database {
         }
     }
 
+    init(db: FMDatabase) {
+        fmdb = db
+        guard fmdb.open() else {
+            fatalError("Failed to open the database. \(fmdb.lastErrorMessage())")
+        }
+    }
+
     func inTransaction(_ executeBlock: () throws -> Void) throws {
         guard fmdb.beginTransaction() else { throw fmdb.lastError() }
 

--- a/native/ios/WatermelonDB/Database.swift
+++ b/native/ios/WatermelonDB/Database.swift
@@ -7,33 +7,14 @@ class Database {
 
     private let fmdb: FMDatabase
 
-    init(_ name: String?) {
-        if let name = name {
-            // Path to the database
-            // swiftlint:disable:next force_try
-            let url = try! FileManager.default
-                .url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
-                .appendingPathComponent(name)
-
-            consoleLog("Database is at: \(url.path)")
-
-            // Open a connection
-            fmdb = FMDatabase(path: url.path)
-        } else {
-            // Open in-memory database (for testing)
-            fmdb = FMDatabase(path: nil)
-        }
+    init(path: String) {
+        fmdb = FMDatabase(path: path)
 
         guard fmdb.open() else {
             fatalError("Failed to open the database. \(fmdb.lastErrorMessage())")
         }
-    }
 
-    init(db: FMDatabase) {
-        fmdb = db
-        guard fmdb.open() else {
-            fatalError("Failed to open the database. \(fmdb.lastErrorMessage())")
-        }
+        consoleLog("Opened database at: \(path)")
     }
 
     func inTransaction(_ executeBlock: () throws -> Void) throws {

--- a/native/ios/WatermelonDB/DatabaseBridge.m
+++ b/native/ios/WatermelonDB/DatabaseBridge.m
@@ -90,9 +90,4 @@ RCT_EXTERN_METHOD(removeLocal:(nonnull NSNumber *)connectionTag
   reject:(RCTPromiseRejectBlock)reject
 )
 
-RCT_EXTERN_METHOD(unsafeClearCachedRecords:(nonnull NSNumber *)connectionTag
-  resolve:(RCTPromiseResolveBlock)resolve
-  reject:(RCTPromiseRejectBlock)reject
-)
-
 @end

--- a/native/ios/WatermelonDB/DatabaseBridge.swift
+++ b/native/ios/WatermelonDB/DatabaseBridge.swift
@@ -57,7 +57,7 @@ final public class DatabaseBridge: NSObject {
     }
 
     @objc(setUpWithMigrations:databaseName:migrations:fromVersion:toVersion:resolve:reject:)
-    func setUpWithMigrations(tag: ConnectionTag,
+    func setUpWithMigrations(tag: ConnectionTag, // swiftlint:disable:this function_parameter_count
                              databaseName: String,
                              migrations: Database.SQL,
                              fromVersion: NSNumber,

--- a/native/ios/WatermelonDB/DatabaseBridge.swift
+++ b/native/ios/WatermelonDB/DatabaseBridge.swift
@@ -210,14 +210,6 @@ final public class DatabaseBridge: NSObject {
         }
     }
 
-    @objc(unsafeClearCachedRecords:resolve:reject:)
-    func unsafeClearCachedRecords(tag: ConnectionTag,
-                                  resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        withDriver(tag, resolve, reject) {
-            $0.unsafeClearCachedRecords()
-        }
-    }
-
     private func withDriver(_ connectionTag: ConnectionTag,
                             _ resolve: @escaping RCTPromiseResolveBlock,
                             _ reject: @escaping RCTPromiseRejectBlock,

--- a/native/ios/WatermelonDB/DatabaseDriver.swift
+++ b/native/ios/WatermelonDB/DatabaseDriver.swift
@@ -35,6 +35,7 @@ class DatabaseDriver {
     }
 
     private init(dbName: String) {
+        // swiftlint:disable:next force_try
         let path = try! FileManager.default
             .url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
             .appendingPathComponent("\(dbName).db")

--- a/native/ios/WatermelonDB/DatabaseDriver.swift
+++ b/native/ios/WatermelonDB/DatabaseDriver.swift
@@ -35,7 +35,13 @@ class DatabaseDriver {
     }
 
     private init(dbName: String) {
-        self.database = Database(isTestRunning ? nil : "\(dbName).db")
+        let path = try! FileManager.default
+            .url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+            .appendingPathComponent("\(dbName).db")
+            .path
+
+        // In test env, pass name of memory db
+        self.database = Database(path: isTestRunning ? dbName : path)
     }
 
     func find(table: Database.TableName, id: RecordId) throws -> Any? {

--- a/native/ios/WatermelonDB/DatabaseDriver.swift
+++ b/native/ios/WatermelonDB/DatabaseDriver.swift
@@ -167,12 +167,6 @@ class DatabaseDriver {
         cachedRecords.insert(id)
     }
 
-    func unsafeClearCachedRecords() {
-        if isTestRunning {
-            cachedRecords = []
-        }
-    }
-
 // MARK: - Other private details
 
     private enum SchemaCompatibility {

--- a/native/iosTest/WatermelonTester.xcodeproj/project.pbxproj
+++ b/native/iosTest/WatermelonTester.xcodeproj/project.pbxproj
@@ -643,6 +643,7 @@
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				6E0A6C1421661F7700195262 /* Run SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -1083,6 +1084,24 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-WatermelonTesterTests/Pods-WatermelonTesterTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		6E0A6C1421661F7700195262 /* Run SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    cd ../../\n    yarn swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download by running `brew install swiftlint`\"\nfi\n";
 		};
 		FBDE50819C02F2F4954F1CCD /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/native/iosTest/WatermelonTesterTests/DatabaseDriverTests.swift
+++ b/native/iosTest/WatermelonTesterTests/DatabaseDriverTests.swift
@@ -33,18 +33,6 @@ class DatabaseDriverTests: XCTestCase {
     func testSetUp() {
         let db = newDatabase()
         expect(try! db.database.count("select count(*) as count from sqlite_master")) > 0
-
-        // TODO: remove me
-        let db1 = Database(path: "file:memdb1?mode=memory&cache=shared")
-
-        try! db1.execute("create table tests (a)", [])
-        expect(try! db1.count("select count(*) as count from tests")) == 0
-
-        try! db1.execute("insert into tests (a) values (10)")
-        expect(try! db1.count("select count(*) as count from tests")) == 1
-
-        let db2 = Database(path: "file:memdb1?mode=memory&cache=shared")
-        expect(try! db2.count("select count(*) as count from tests")) == 1
     }
 
     func testExecuteBatch() {

--- a/native/iosTest/WatermelonTesterTests/DatabaseDriverTests.swift
+++ b/native/iosTest/WatermelonTesterTests/DatabaseDriverTests.swift
@@ -26,7 +26,7 @@ let testSchema = """
     """
 
 func newDatabase() -> DatabaseDriver {
-    return DatabaseDriver(dbName: "test", setUpWithSchema: (version: 1, sql: testSchema))
+    return DatabaseDriver(dbName: ":memory:", setUpWithSchema: (version: 1, sql: testSchema))
 }
 
 class DatabaseDriverTests: XCTestCase {
@@ -35,7 +35,7 @@ class DatabaseDriverTests: XCTestCase {
         expect(try! db.database.count("select count(*) as count from sqlite_master")) > 0
 
         // TODO: remove me
-        let db1 = Database(db: FMDatabase(path: "file:memdb1?mode=memory&cache=shared"))
+        let db1 = Database(path: "file:memdb1?mode=memory&cache=shared")
 
         try! db1.execute("create table tests (a)", [])
         expect(try! db1.count("select count(*) as count from tests")) == 0
@@ -43,7 +43,7 @@ class DatabaseDriverTests: XCTestCase {
         try! db1.execute("insert into tests (a) values (10)")
         expect(try! db1.count("select count(*) as count from tests")) == 1
 
-        let db2 = Database(db: FMDatabase(path: "file:memdb1?mode=memory&cache=shared"))
+        let db2 = Database(path: "file:memdb1?mode=memory&cache=shared")
         expect(try! db2.count("select count(*) as count from tests")) == 1
     }
 

--- a/native/iosTest/WatermelonTesterTests/DatabaseDriverTests.swift
+++ b/native/iosTest/WatermelonTesterTests/DatabaseDriverTests.swift
@@ -33,6 +33,18 @@ class DatabaseDriverTests: XCTestCase {
     func testSetUp() {
         let db = newDatabase()
         expect(try! db.database.count("select count(*) as count from sqlite_master")) > 0
+
+        // TODO: remove me
+        let db1 = Database(db: FMDatabase(path: "file:memdb1?mode=memory&cache=shared"))
+
+        try! db1.execute("create table tests (a)", [])
+        expect(try! db1.count("select count(*) as count from tests")) == 0
+
+        try! db1.execute("insert into tests (a) values (10)")
+        expect(try! db1.count("select count(*) as count from tests")) == 1
+
+        let db2 = Database(db: FMDatabase(path: "file:memdb1?mode=memory&cache=shared"))
+        expect(try! db2.count("select count(*) as count from tests")) == 1
     }
 
     func testExecuteBatch() {

--- a/src/Database/test.js
+++ b/src/Database/test.js
@@ -23,7 +23,7 @@ describe('watermelondb/Database', () => {
     expect(database.collections.get('non_existent')).toBeUndefined()
   })
   it('can batch records', async () => {
-    const { database, tasksCollection: collection } = mockDatabase()
+    let { database, tasksCollection: collection } = mockDatabase()
     const adapterBatchSpy = jest.spyOn(database.adapter, 'batch')
 
     const m1 = await collection.create()
@@ -76,14 +76,15 @@ describe('watermelondb/Database', () => {
     expect(recordObserver).toHaveBeenCalledTimes(2)
 
     // simulate reload -- check if changes actually got saved
-    // TODO: There should be an API for that
-    const { adapter } = database
-    const database2 = new Database({ adapter, schema: testSchema, modelClasses: [MockTask] })
-    const collection2 = database2.collections.get('mock_tasks')
-    await adapter.unsafeClearCachedRecords()
+    database = new Database({
+      adapter: database.adapter.testClone(),
+      schema: testSchema,
+      modelClasses: [MockTask],
+    })
+    collection = database.collections.get('mock_tasks')
 
-    const fetchedM1 = await collection2.find(m1.id)
-    const fetchedM2 = await collection2.find(m2.id)
+    const fetchedM1 = await collection.find(m1.id)
+    const fetchedM2 = await collection.find(m2.id)
     expect(fetchedM1.name).toBe('bar1')
     expect(fetchedM2.name).toBe('baz1')
   })

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -29,7 +29,7 @@ export default () => [
     (_adapter, AdapterClass) => async () => {
       const schema = { ...testSchema, version: 10 }
 
-      const makeAdapter = options => new AdapterClass({ dbName: 'test', schema, ...options })
+      const makeAdapter = options => new AdapterClass({ isTest: true, schema, ...options })
       const adapterWithMigrations = migrations =>
         makeAdapter({ migrationsExperimental: migrations })
 

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -88,12 +88,14 @@ export default () => [
   ],
   [
     'can find single records',
-    adapter => async () => {
+    _adapter => async () => {
+      let adapter = _adapter
+
       // side-add records
       const s1 = makeMockTask({ id: 's1', text1: 'bar', order: 1 })
       const s2 = makeMockTask({ id: 's2', bool1: true, order: 2 })
       await adapter.batch([['create', s1], ['create', s2]])
-      await adapter.unsafeClearCachedRecords()
+      adapter = adapter.testClone()
 
       // add records with caching
       const s3 = makeMockTask({ id: 's3', text1: 'baz' })

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -29,7 +29,7 @@ export default () => [
     (_adapter, AdapterClass) => async () => {
       const schema = { ...testSchema, version: 10 }
 
-      const makeAdapter = options => new AdapterClass({ isTest: true, schema, ...options })
+      const makeAdapter = options => new AdapterClass({ schema, ...options })
       const adapterWithMigrations = migrations =>
         makeAdapter({ migrationsExperimental: migrations })
 

--- a/src/adapters/lokijs/common.js
+++ b/src/adapters/lokijs/common.js
@@ -21,7 +21,6 @@ export const actions = {
   GET_LOCAL: 'GET_LOCAL',
   SET_LOCAL: 'SET_LOCAL',
   REMOVE_LOCAL: 'REMOVE_LOCAL',
-  UNSAFE_CLEAR_CACHED_RECORDS: 'UNSAFE_CLEAR_CACHED_RECORDS',
 }
 
 export const responseActions = {

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -125,10 +125,4 @@ export default class LokiJSAdapter implements DatabaseAdapter {
   removeLocal(key: string): Promise<void> {
     return this.workerBridge.send(REMOVE_LOCAL, [key])
   }
-
-  async unsafeClearCachedRecords(): Promise<void> {
-    if (process.env.NODE_ENV === 'test') {
-      await this.workerBridge.send(UNSAFE_CLEAR_CACHED_RECORDS, [])
-    }
-  }
 }

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -33,7 +33,6 @@ const {
   REMOVE_LOCAL,
   GET_DELETED_RECORDS,
   DESTROY_DELETED_RECORDS,
-  UNSAFE_CLEAR_CACHED_RECORDS,
 } = actions
 
 type LokiAdapterOptions = $Exact<{

--- a/src/adapters/lokijs/worker/executor.js
+++ b/src/adapters/lokijs/worker/executor.js
@@ -187,12 +187,6 @@ export default class LokiExecutor {
     }
   }
 
-  unsafeClearCachedRecords(): void {
-    if (process.env.NODE_ENV === 'test') {
-      this.cachedRecords.clear()
-    }
-  }
-
   // *** Internals ***
 
   async _openDatabase(adapter?: LokiMemoryAdapter): Promise<void> {

--- a/src/adapters/lokijs/worker/lokiExtensions.js
+++ b/src/adapters/lokijs/worker/lokiExtensions.js
@@ -3,12 +3,12 @@
 import Loki, { LokiMemoryAdapter } from 'lokijs'
 import LokiIndexedAdapter from 'lokijs/src/loki-indexed-adapter'
 
-export function newLoki(name: string): Loki {
-  const adapter =
+export function newLoki(name: ?string, peristenceAdapter?: LokiMemoryAdapter): Loki {
+  const newAdapter =
     process.env.NODE_ENV === 'test' ? new LokiMemoryAdapter() : new LokiIndexedAdapter(name)
 
   return new Loki(name, {
-    adapter,
+    adapter: peristenceAdapter || newAdapter,
     autosave: true,
     autosaveInterval: 250, // TODO: Remove this and force database save when we have transactions
     env: 'BROWSER', // TODO: ?

--- a/src/adapters/lokijs/worker/lokiWorker.js
+++ b/src/adapters/lokijs/worker/lokiWorker.js
@@ -30,7 +30,6 @@ const executorMethods = {
   [actions.MARK_AS_DELETED]: ExecutorProto.markAsDeleted,
   [actions.GET_DELETED_RECORDS]: ExecutorProto.getDeletedRecords,
   [actions.DESTROY_DELETED_RECORDS]: ExecutorProto.destroyDeletedRecords,
-  [actions.UNSAFE_CLEAR_CACHED_RECORDS]: ExecutorProto.unsafeClearCachedRecords,
 }
 
 const { RESPONSE_SUCCESS, RESPONSE_ERROR } = responseActions

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -94,11 +94,13 @@ export default class SQLiteAdapter implements DatabaseAdapter {
 
   // Allows tests to create a new adapter connecting to the same data as the old one, simulating an
   // app relaunching - for testing caching, setup, migrations
-  static testReopenDatabase(adapter: SQLiteAdapter, options: SQLiteAdapterOptions): SQLiteAdapter {
+  testClone(options?: $Shape<SQLiteAdapterOptions> = {}): SQLiteAdapter {
     return new SQLiteAdapter({
-      ...options,
-      dbName: adapter._dbName,
+      dbName: this._dbName,
       isTest: true,
+      schema: this.schema,
+      ...(this.migrations ? { migrationsExperimental: this.migrations } : {}),
+      ...options,
     })
   }
 

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -63,7 +63,6 @@ type NativeBridgeType = {
   getLocal: (ConnectionTag, string) => Promise<?string>,
   setLocal: (ConnectionTag, string, string) => Promise<void>,
   removeLocal: (ConnectionTag, string) => Promise<void>,
-  unsafeClearCachedRecords: ConnectionTag => Promise<void>,
 }
 const Native: NativeBridgeType = NativeModules.DatabaseBridge
 
@@ -234,10 +233,6 @@ export default class SQLiteAdapter implements DatabaseAdapter {
 
   removeLocal(key: string): Promise<void> {
     return Native.removeLocal(this._tag, key)
-  }
-
-  unsafeClearCachedRecords(): Promise<void> {
-    return Native.unsafeClearCachedRecords(this._tag)
   }
 
   _encodedSchema(): SQL {

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -92,8 +92,6 @@ export default class SQLiteAdapter implements DatabaseAdapter {
     devLogSetUp(() => this._init())
   }
 
-  // Allows tests to create a new adapter connecting to the same data as the old one, simulating an
-  // app relaunching - for testing caching, setup, migrations
   testClone(options?: $Shape<SQLiteAdapterOptions> = {}): SQLiteAdapter {
     return new SQLiteAdapter({
       dbName: this._dbName,

--- a/src/adapters/sqlite/integrationTest.js
+++ b/src/adapters/sqlite/integrationTest.js
@@ -2,7 +2,7 @@ import SQLiteAdapter from './index'
 import { testSchema } from '../__tests__/helpers'
 import commonTests from '../__tests__/commonTests'
 
-const newAdapter = () => new SQLiteAdapter({ dbName: 'test', schema: testSchema })
+const newAdapter = () => new SQLiteAdapter({ isTest: true, schema: testSchema })
 
 const SQLiteAdapterTest = spec => {
   spec.describe('watermelondb/adapters/sqlite', () => {

--- a/src/adapters/sqlite/integrationTest.js
+++ b/src/adapters/sqlite/integrationTest.js
@@ -2,7 +2,7 @@ import SQLiteAdapter from './index'
 import { testSchema } from '../__tests__/helpers'
 import commonTests from '../__tests__/commonTests'
 
-const newAdapter = () => new SQLiteAdapter({ isTest: true, schema: testSchema })
+const newAdapter = () => new SQLiteAdapter({ schema: testSchema })
 
 const SQLiteAdapterTest = spec => {
   spec.describe('watermelondb/adapters/sqlite', () => {

--- a/src/adapters/type.js
+++ b/src/adapters/type.js
@@ -48,7 +48,4 @@ export interface DatabaseAdapter {
 
   // Removes key from local storage
   removeLocal(key: string): Promise<void>;
-
-  // Do not use — only for testing purposes
-  unsafeClearCachedRecords(): Promise<void>;
 }

--- a/src/index.integrationTests.native.js
+++ b/src/index.integrationTests.native.js
@@ -1,4 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable import/first */
+
+process.env.NODE_ENV = 'test'
 
 import React from 'react'
 import { AppRegistry, Text, NativeModules } from 'react-native'


### PR DESCRIPTION
- Refactors how Adapters are tested:
  - cleans up shared tests file
  - removes unsafeClearCachedRecords - this "simulated" DB behavior when app is restarted. but this was kind of a hack. we tested a behavior by just clearing cache  array, not actually reconnecting to the database. This also wouldn't allow for schema setup / migration testing
  - adds `adapter.testClone()` method. It returns a new SQLiteAdapter/LokiAdapter object that connects to the same underlying database. (On Loki, we pass the same LokiMemoryAdapter, for SQLite we pass a magic database path for an in-memory database that you can reconnect to). This much more closely simulates an app restart
- `dbName` option in adapters is now optional (simplifies Watermelon setup for new users)