### PR TITLE
[Travis] restart ADB and retry test on fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
         - yarn
       script:
         - TERM=dumb yarn ktlint
-        - android-wait-for-emulator
+        - TERM=dumb android-wait-for-emulator
         - adb kill-server
         - adb start-server
         - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,9 @@ matrix:
         - yarn
       script:
         - TERM=dumb yarn ktlint
-        - TERM=dumb android-wait-for-emulator
-        - adb kill-server
-        - adb start-server
+        - android-wait-for-emulator
         - adb shell input keyevent 82 &
-        - TERM=dumb yarn test:android
+        - ./scripts/retryEmuAndTest
       after_failure:
         - adb logcat -d > logcat.txt
         - echo "$(cat logcat.txt)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
       script:
         - TERM=dumb yarn ktlint
         - android-wait-for-emulator
+        - adb kill-server
         - adb start-server
         - adb shell input keyevent 82 &
         - TERM=dumb yarn test:android

--- a/native/androidTest/app/src/main/AndroidManifest.xml
+++ b/native/androidTest/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-  <uses-permission android:name="android.permission.INTERNET" />
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"

--- a/scripts/retryEmuAndTest
+++ b/scripts/retryEmuAndTest
@@ -2,7 +2,6 @@
 
 TERM=dumb yarn test:android;
 if [ "$?" -ne 0 ]; then
-  echo "eeecho" &
   adb kill-server &
   adb start-server &
   TERM=dumb yarn test:android

--- a/scripts/retryEmuAndTest
+++ b/scripts/retryEmuAndTest
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 TERM=dumb yarn test:android;
-if { "$?" -ne 0 } then
+if [ "$?" -ne 0 ]; then
+  echo "eeecho" &
   adb kill-server &
   adb start-server &
   TERM=dumb yarn test:android
-fi
+fi;

--- a/scripts/retryEmuAndTest
+++ b/scripts/retryEmuAndTest
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+TERM=dumb yarn test:android;
+if { "$?" -ne 0 } then
+  adb kill-server &
+  adb start-server &
+  TERM=dumb yarn test:android
+fi


### PR DESCRIPTION
My mission is to create the most robust Android testing CI script ever. So I've made simple script to just retry test if it fails for the first time. It Should lower rate of false-negatives in CI created by some problem with ADB.  **_IT'S NOT GONNA BE FOOLPROOF_** but still better than nothing - right?