### PR TITLE
LIKE query 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ All notable changes to this project will be documented in this file.
 
 - Updated Flow to 0.83
 
+### Added
+
+- Query like
+
+
 ### Refactoring
 
 - [WIP] Migrations

--- a/examples/native/src/components/BlogList.js
+++ b/examples/native/src/components/BlogList.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { View } from 'react-native'
 
+import { Q } from '@nozbe/watermelondb'
 import withObservables from '@nozbe/with-observables'
 
 import ListItem from './helpers/ListItem'
@@ -20,11 +21,10 @@ const BlogList = ({ blogs, navigation }) => (
     ))}
   </View>
 )
-
-const enhance = withObservables([], ({ database }) => ({
+const enhance = withObservables(['search'], ({ database, search }) => ({
   blogs: database.collections
     .get('blogs')
-    .query()
+    .query(Q.where('name', Q.like(`%${search}%`)))
     .observe(),
 }))
 

--- a/examples/native/src/components/Root.js
+++ b/examples/native/src/components/Root.js
@@ -1,5 +1,5 @@
-import React, { Component } from 'react'
-import { ScrollView, SafeAreaView, Alert, Text, View, Image } from 'react-native'
+import React, { Component, Fragment } from 'react'
+import { ScrollView, SafeAreaView, Alert, Text, View, Image, TextInput } from 'react-native'
 
 import { generate100, generate10k } from '../models/generate'
 import Button from './helpers/Button'
@@ -9,7 +9,11 @@ import BlogList from './BlogList'
 import logoSrc from './assets/logo-app.png'
 
 class Root extends Component {
-  state = { isGenerating: false }
+  state = {
+    isGenerating: false,
+    search: '',
+    isSearchFocused: false,
+  }
 
   generateWith = async generator => {
     this.setState({ isGenerating: true })
@@ -24,21 +28,40 @@ class Root extends Component {
 
   generate10k = () => this.generateWith(generate10k)
 
+  handleTextChanges = v => this.setState({ search: v })
+
+  handleOnFocus = () => this.setState({ isSearchFocused: true })
+
+  handleOnBlur = () => this.setState({ isSearchFocused: false})
+
   render() {
+    const { search, isGenerating, isSearchFocused } = this.state
+    const { database, navigation, timeToLaunch } = this.props
+
     return (
       <ScrollView>
         <SafeAreaView>
-          <Image style={styles.logo} source={logoSrc} />
-          <Text style={styles.post}>Launch time: {this.props.timeToLaunch} ms</Text>
-          <View style={styles.marginContainer}>
-            <Text style={styles.header}>Generate:</Text>
-            <View style={styles.buttonContainer}>
-              <Button title="100 records" onPress={this.generate100} />
-              <Button title="10,000 records" onPress={this.generate10k} />
-            </View>
-          </View>
-          {!this.state.isGenerating && (
-            <BlogList database={this.props.database} navigation={this.props.navigation} />
+          {!isSearchFocused && (
+            <Fragment>
+              <Image style={styles.logo} source={logoSrc} />
+              <Text style={styles.post}>Launch time: {timeToLaunch} ms</Text>
+              <View style={styles.marginContainer}>
+                <Text style={styles.header}>Generate:</Text>
+                <View style={styles.buttonContainer}>
+                  <Button title="100 records" onPress={this.generate100} />
+                  <Button title="10,000 records" onPress={this.generate10k} />
+                </View>
+              </View>
+            </Fragment>
+          )}
+          <TextInput style={{ padding: 5, fontSize: 16 }}
+            placeholder="Search ..."
+            defaultValue=""
+            onFocus={this.handleOnFocus}
+            onBlur={this.handleOnBlur}
+            onChangeText={this.handleTextChanges} />
+          {!isGenerating && (
+            <BlogList database={database} search={search} navigation={navigation} />
           )}
         </SafeAreaView>
       </ScrollView>

--- a/examples/web/.gitignore
+++ b/examples/web/.gitignore
@@ -1,1 +1,2 @@
 build/
+node_modules/

--- a/examples/web/src/components/BlogList/index.js
+++ b/examples/web/src/components/BlogList/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { compose, withStateHandlers, withHandlers } from 'recompose'
+import { Q } from '@nozbe/watermelondb'
 import withObservables from '@nozbe/with-observables'
 
 import ListItem from 'components/ListItem'
@@ -39,12 +40,13 @@ const BlogList = ({ blogs, setActiveItem, activeItem }) => (
 )
 
 const enhance = compose(
-  withObservables([], ({ database }) => ({
-    blogs: database.collections
-      .get('blogs')
-      .query()
-      .observe(),
-  })),
+  withObservables(['search'], ({ database, search }) => ({
+      blogs: database.collections
+        .get('blogs')
+        .query(Q.where('name', Q.like(`${search}%`)))
+        .observe(),
+    })
+  ),
   withStateHandlers(
     {
       activeItem: null,

--- a/examples/web/src/components/Root/index.js
+++ b/examples/web/src/components/Root/index.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import withObservables from '@nozbe/with-observables'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import { generate100, generate10k } from 'models/generate'
 
@@ -16,7 +15,10 @@ class Root extends Component {
   state = { isGenerating: false }
 
   generateWith = async generator => {
-    this.setState({ isGenerating: true })
+    this.setState({
+      isGenerating: true,
+      search: '',
+    })
 
     const count = await generator(this.props.database)
 
@@ -29,9 +31,13 @@ class Root extends Component {
 
   generate10k = () => this.generateWith(generate10k)
 
+  handleTextChange = e => {
+    this.setState({ search: e.target.value })
+  }
+
   render() {
     const { database } = this.props
-    const { isGenerating } = this.state
+    const { isGenerating, search } = this.state
 
     return (
       <Router>
@@ -42,8 +48,16 @@ class Root extends Component {
             <Button title="Generate 10,000 records" onClick={this.generate10k} />
           </div>
 
+          <input className={style.searchInput}
+            placeholder="Search ..."
+            type="text"
+            defaultValue=""
+            onChange={this.handleTextChange} />
+
           <div className={style.content}>
-            <div className={style.sidebar}>{!isGenerating && <BlogList database={database} />}</div>
+            <div className={style.sidebar}>
+              {!isGenerating && <BlogList search={search} database={database} />}
+            </div>
             <div className={style.postList}>
               <Route path="/blog/:blogId"
                 render={props =>

--- a/examples/web/src/components/Root/style.css
+++ b/examples/web/src/components/Root/style.css
@@ -54,3 +54,12 @@
   background: #fff;
   overflow: auto;
 }
+
+.searchInput {
+  width: 230px;
+  margin-left: 10px;
+  padding: 5px;
+  font-size: 16px;
+  border: none;
+  outline: none;
+}

--- a/src/QueryDescription/index.js
+++ b/src/QueryDescription/index.js
@@ -38,6 +38,7 @@ export type Operator =
   | 'oneOf'
   | 'notIn'
   | 'between'
+  | 'like'
 
 export type ColumnDescription = $Exact<{ column: ColumnName }>
 export type ComparisonRight =
@@ -160,6 +161,10 @@ export function notIn(values: NonNullValue[]): Comparison {
 // Number is between two numbers (greater than or equal left, and less than or equal right)
 export function between(left: number, right: number): Comparison {
   return { operator: 'between', right: { values: [left, right] } }
+}
+
+export function like(value: NonNullValue[]): Comparison {
+  return { operator: 'like', right: { value } }
 }
 
 export function column(name: ColumnName): ColumnDescription {

--- a/src/QueryDescription/index.js
+++ b/src/QueryDescription/index.js
@@ -163,7 +163,7 @@ export function between(left: number, right: number): Comparison {
   return { operator: 'between', right: { values: [left, right] } }
 }
 
-export function like(value: NonNullValue[]): Comparison {
+export function like(value: Value): Comparison {
   return { operator: 'like', right: { value } }
 }
 

--- a/src/__tests__/databaseTests.js
+++ b/src/__tests__/databaseTests.js
@@ -301,6 +301,18 @@ export const matchTests = [
     matching: [{ id: 'm1' }, { id: 'm2', num1: null }, { id: 'm3', num1: 10 }],
     nonMatching: [{ id: 'n1', num1: 0 }, { id: 'n2', num1: 2 }],
   },
+  {
+    name: 'match like',
+    query: [Q.where('value', Q.like('%ipsum%'))],
+    matching: [
+      { id: 'm1', value: 'Lorem ipsum dolor sit amet,' },
+      { id: 'm2', value: 'Lorem Ipsum dolor sit amet,' },
+    ],
+    nonMatching: [
+      { id: 'n1', value: 'consectetur adipiscing elit.' },
+      { id: 'n2', value: null },
+    ],
+  },
 ]
 
 export const joinTests = [

--- a/src/__tests__/databaseTests.js
+++ b/src/__tests__/databaseTests.js
@@ -302,7 +302,7 @@ export const matchTests = [
     nonMatching: [{ id: 'n1', num1: 0 }, { id: 'n2', num1: 2 }],
   },
   {
-    name: 'match like',
+    name: 'match like (string)',
     query: [Q.where('value', Q.like('%ipsum%'))],
     matching: [
       { id: 'm1', value: 'Lorem ipsum dolor sit amet,' },
@@ -312,6 +312,17 @@ export const matchTests = [
       { id: 'n1', value: 'consectetur adipiscing elit.' },
       { id: 'n2', value: null },
     ],
+  },
+  {
+    name: 'match like (null)',
+    query: [Q.where('value', Q.like(null))],
+    matching: [
+      { id: 'm1', value: 'Lorem ipsum dolor sit amet,' },
+      { id: 'm2', value: 'Lorem Ipsum dolor sit amet,' },
+      { id: 'm3', value: 'consectetur adipiscing elit.' },
+      { id: 'm4', value: null },
+    ],
+    nonMatching: [],
   },
 ]
 

--- a/src/adapters/lokijs/worker/encodeQuery/index.js
+++ b/src/adapters/lokijs/worker/encodeQuery/index.js
@@ -87,9 +87,17 @@ const noNullComparisons: OperatorFunction => OperatorFunction = operator => valu
   $and: [operator(value), weakNotEqual(null)],
 })
 
-const like = value => ({
-  $regex: new RegExp(value.replace(/%/g, '.*').replace('_', '.'), 'i'),
-})
+const like: OperatorFunction = value => {
+  if (typeof value === 'string') {
+    return {
+      $regex: new RegExp(value.replace(/%/g, '.*').replace('_', '.'), 'i'),
+    }
+  }
+
+  return {
+    $regex: new RegExp('.*', 'i'),
+  }
+}
 
 const operators: { [Operator]: OperatorFunction } = {
   eq: objOf('$aeq'),

--- a/src/adapters/lokijs/worker/encodeQuery/index.js
+++ b/src/adapters/lokijs/worker/encodeQuery/index.js
@@ -51,6 +51,7 @@ type LokiOperator =
   | '$in'
   | '$nin'
   | '$between'
+  | '$regex'
 type LokiKeyword = LokiOperator | '$and' | '$or'
 
 export type LokiJoin = $Exact<{
@@ -86,6 +87,10 @@ const noNullComparisons: OperatorFunction => OperatorFunction = operator => valu
   $and: [operator(value), weakNotEqual(null)],
 })
 
+const like = value => ({
+  $regex: new RegExp(value.replace(/%/g, '.*').replace('_', '.'), 'i'),
+})
+
 const operators: { [Operator]: OperatorFunction } = {
   eq: objOf('$aeq'),
   notEq: weakNotEqual,
@@ -97,6 +102,7 @@ const operators: { [Operator]: OperatorFunction } = {
   oneOf: objOf('$in'),
   notIn: noNullComparisons(objOf('$nin')),
   between: objOf('$between'),
+  like,
 }
 
 const encodeComparison: Comparison => LokiRawQuery = ({ operator, right }) =>

--- a/src/adapters/sqlite/encodeQuery/index.js
+++ b/src/adapters/sqlite/encodeQuery/index.js
@@ -56,6 +56,7 @@ const operators: { [Operator]: string } = {
   oneOf: 'in',
   notIn: 'not in',
   between: 'between',
+  like: 'like',
 }
 
 const encodeComparison = (table: TableName<any>, comparison: Comparison) => {

--- a/src/observation/encodeMatcher/operators.js
+++ b/src/observation/encodeMatcher/operators.js
@@ -24,9 +24,15 @@ const noNullComparisons: OperatorFunction => OperatorFunction = operator => (lef
 // Same as `a > b`, but `5 > undefined` is also true
 const weakGt = (left, right) => left > right || (left != null && right == null)
 
-export const like = (left, right) => (
-  left && left.match(new RegExp(right.replace(/%/g, '.*').replace('_', '.'), 'i'))
-)
+const handleLikeValue = (v, defaultV) => typeof v === 'string' ? v : defaultV
+
+export const like: OperatorFunction = (left, right) => {
+  const leftV = handleLikeValue(left, '')
+  const rightV = handleLikeValue(right, '.*')
+  const regexp = rightV.replace(/%/g, '.*').replace('_', '.')
+
+  return leftV.match(new RegExp(regexp, 'i'))
+}
 
 const operators: { [Operator]: OperatorFunction } = {
   eq: rawFieldEquals,

--- a/src/observation/encodeMatcher/operators.js
+++ b/src/observation/encodeMatcher/operators.js
@@ -24,6 +24,10 @@ const noNullComparisons: OperatorFunction => OperatorFunction = operator => (lef
 // Same as `a > b`, but `5 > undefined` is also true
 const weakGt = (left, right) => left > right || (left != null && right == null)
 
+export const like = (left, right) => (
+  left.match(new RegExp(right.replace(/%/g, '.*').replace('_', '.'), 'i'))
+)
+
 const operators: { [Operator]: OperatorFunction } = {
   eq: rawFieldEquals,
   notEq: complement(rawFieldEquals),
@@ -35,6 +39,7 @@ const operators: { [Operator]: OperatorFunction } = {
   oneOf: contains,
   notIn: noNullComparisons(complement(contains)),
   between,
+  like,
 }
 
 export default operators

--- a/src/observation/encodeMatcher/operators.js
+++ b/src/observation/encodeMatcher/operators.js
@@ -25,7 +25,7 @@ const noNullComparisons: OperatorFunction => OperatorFunction = operator => (lef
 const weakGt = (left, right) => left > right || (left != null && right == null)
 
 export const like = (left, right) => (
-  left.match(new RegExp(right.replace(/%/g, '.*').replace('_', '.'), 'i'))
+  left && left.match(new RegExp(right.replace(/%/g, '.*').replace('_', '.'), 'i'))
 )
 
 const operators: { [Operator]: OperatorFunction } = {


### PR DESCRIPTION
Make choice to use SQL LIKE syntax.
> For lokijs and javascript observer the **LIKE** query is converted to **Regexp**

```js
Q.where('name', Q.like('%value%'))
```

Issue: #112