### PR TITLE
Subactions

### DIFF
--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -13,7 +13,7 @@ import type { CollectionChangeSet } from '../Collection'
 import type { TableName, AppSchema } from '../Schema'
 
 import CollectionMap from './CollectionMap'
-import ActionQueue from './ActionQueue'
+import ActionQueue, { type ActionInterface } from './ActionQueue'
 
 type DatabaseProps = $Exact<{
   adapter: DatabaseAdapter,
@@ -71,7 +71,7 @@ export default class Database {
     })
   }
 
-  action<T>(work: () => Promise<T>, description?: string): Promise<T> {
+  action<T>(work: ActionInterface => Promise<T>, description?: string): Promise<T> {
     return this._actionQueue.enqueue(work, description)
   }
 

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -71,6 +71,7 @@ export default class Database {
     })
   }
 
+  // TODO: Document me!
   action<T>(work: ActionInterface => Promise<T>, description?: string): Promise<T> {
     return this._actionQueue.enqueue(work, description)
   }

--- a/src/Model/index.js
+++ b/src/Model/index.js
@@ -162,6 +162,12 @@ export default class Model {
     return this.collection.database.batch(...records)
   }
 
+  // TODO: Document me
+  // To be used by Model subclass methods only
+  subAction<T>(action: () => Promise<T>): Promise<T> {
+    return this.collection.database._actionQueue.subAction(action)
+  }
+
   get table(): TableName<this> {
     return this.constructor.table
   }

--- a/src/__tests__/testModels.js
+++ b/src/__tests__/testModels.js
@@ -1,5 +1,5 @@
 import { appSchema, tableSchema } from '../Schema'
-import { field, relation, immutableRelation, action } from '../decorators'
+import { field, relation, immutableRelation } from '../decorators'
 import Model from '../Model'
 import Database from '../Database'
 import LokiJSAdapter from '../adapters/lokijs'
@@ -55,11 +55,6 @@ export class MockTask extends Model {
 
   @relation('mock_projects', 'project_id')
   project
-
-  @action
-  async returnArgs(a, b, ...c) {
-    return [this.name, a, b, c]
-  }
 }
 
 export class MockComment extends Model {

--- a/src/decorators/action/index.js
+++ b/src/decorators/action/index.js
@@ -7,7 +7,7 @@ export default function action(target: Object, key: string, descriptor: Descript
   return {
     ...descriptor,
     value(...args): Promise<any> {
-      return this.collection.database.action(descriptor.value.bind(this, ...args), actionName)
+      return this.collection.database.action(() => descriptor.value.apply(this, args), actionName)
     },
   }
 }

--- a/src/decorators/action/index.js
+++ b/src/decorators/action/index.js
@@ -2,6 +2,7 @@
 
 import type { Descriptor } from '../../utils/common/makeDecorator'
 
+// TODO: Document me
 export default function action(target: Object, key: string, descriptor: Descriptor): Descriptor {
   const actionName = `${target.table}.${key}`
   return {

--- a/src/decorators/action/test.js
+++ b/src/decorators/action/test.js
@@ -6,6 +6,11 @@ class MockTaskExtended extends MockTask {
   async returnArgs(a, b, ...c) {
     return [this.name, a, b, c]
   }
+
+  @action
+  async nested(...args) {
+    return this.subAction(() => this.returnArgs('sub', ...args))
+  }
 }
 
 describe('@action', () => {
@@ -20,5 +25,11 @@ describe('@action', () => {
     expect(actionSpy).toHaveBeenCalledTimes(1)
     expect(actionSpy.mock.calls[0][0]).toBeInstanceOf(Function)
     expect(actionSpy.mock.calls[0][1]).toBe('mock_tasks.returnArgs')
+  })
+  it('can call subactions using this.subAction', async () => {
+    const { tasksCollection } = mockDatabase({ actionsEnabled: true })
+    const record = new MockTaskExtended(tasksCollection, { name: 'test' })
+
+    expect(await record.nested(1, 2, 3, 4)).toEqual(['test', 'sub', 1, [2, 3, 4]])
   })
 })

--- a/src/decorators/action/test.js
+++ b/src/decorators/action/test.js
@@ -1,9 +1,17 @@
 import { MockTask, mockDatabase } from '../../__tests__/testModels'
+import action from './index'
+
+class MockTaskExtended extends MockTask {
+  @action
+  async returnArgs(a, b, ...c) {
+    return [this.name, a, b, c]
+  }
+}
 
 describe('@action', () => {
   it('calls db.action() and passes arguments correctly', async () => {
     const { database, tasksCollection } = mockDatabase({ actionsEnabled: true })
-    const record = new MockTask(tasksCollection, { name: 'test' })
+    const record = new MockTaskExtended(tasksCollection, { name: 'test' })
 
     const actionSpy = jest.spyOn(database, 'action')
 


### PR DESCRIPTION
adds subaction API, as discussed to be able to call an action from an action, skipping the queue:

```
// direct api
database.action(async action => {
  action.subAction(() => anotherAction())
})

// @action api in Model instances
@action async foo() {
 await  this.subAction(() => this.bar())
}
```