### PR TITLE
Fix type in Migrations.MD

### DIFF
--- a/docs/Advanced/Migrations.md
+++ b/docs/Advanced/Migrations.md
@@ -2,7 +2,7 @@
 
 **Schema migrations** is the mechanism by which you can add new tables and columns to the database in a backward-compatible way.
 
-Without migrations, if a user of your app upgrades from one version to another, their local database will be cleared at launch, and they will use all their data.
+Without migrations, if a user of your app upgrades from one version to another, their local database will be cleared at launch, and they will lose all their data.
 
 ⚠️ Always use migrations!
 


### PR DESCRIPTION
Without migrations, if a user of your app upgrades from one version to another, their local database will be cleared at launch, and they will "use" => "lose" all their data.

Changed use to lose in the above sentence. I am not 100% sure if I am correct, maybe this is a feature and I'm mistaken. If so, please reject this PR.