### PR TITLE
Sync primitives — Part 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Added DatabaseProvider and withDatabase Higher-Order Component to reduce prop drilling.
 - [WIP] Actions API
+- [WIP] Sync primitives
 
 ## 0.7.0 - 2018-10-31
 

--- a/src/Model/helpers.js
+++ b/src/Model/helpers.js
@@ -21,12 +21,3 @@ export const createTimestampsFor = (model: Model) => {
 
   return timestamps
 }
-
-// TODO: Measure and optimize performance!
-
-export function addToRawSet(rawSet: ?string, value: string): string {
-  const array = rawSet ? rawSet.split(',') : []
-  const set = new Set(array)
-  set.add(value)
-  return Array.from(set).join(',')
-}

--- a/src/Model/index.js
+++ b/src/Model/index.js
@@ -17,8 +17,9 @@ import type CollectionMap from '../Database/CollectionMap'
 import { type TableName, type ColumnName, columnName } from '../Schema'
 import type { Value } from '../QueryDescription'
 import { type RawRecord, sanitizedRaw, setRawSanitized } from '../RawRecord'
+import { setRawColumnChange } from '../sync/helpers'
 
-import { createTimestampsFor, hasUpdatedAt, addToRawSet } from './helpers'
+import { createTimestampsFor, hasUpdatedAt } from './helpers'
 
 export type RecordId = string
 
@@ -215,14 +216,7 @@ export default class Model {
       'Not allowed to change deleted records',
     )
 
-    // mark change
-    if (this._raw._status !== 'created') {
-      // Add another changed field
-      this._raw._changed = addToRawSet(this._raw._changed, rawFieldName)
-      this._raw._status = 'updated'
-    }
-
-    // set raw
+    setRawColumnChange(this._raw, rawFieldName)
     setRawSanitized(this._raw, rawFieldName, rawValue, this.collection.schema.columns[rawFieldName])
   }
 }

--- a/src/sync/helpers.js
+++ b/src/sync/helpers.js
@@ -1,0 +1,19 @@
+// @flow
+
+import type { ColumnName } from '..'
+import type { RawRecord } from '../RawRecord'
+
+export function addToRawSet(rawSet: ?string, value: string): string {
+  const array = rawSet ? rawSet.split(',') : []
+  const set = new Set(array)
+  set.add(value)
+  return Array.from(set).join(',')
+}
+
+// Mutates `rawRecord` to mark `columName` as modified for sync purposes
+export function setRawColumnChange(rawRecord: RawRecord, columnName: ColumnName): void {
+  if (rawRecord._status !== 'created') {
+    rawRecord._changed = addToRawSet(rawRecord._changed, columnName)
+    rawRecord._status = 'updated'
+  }
+}

--- a/src/sync/syncHelpers.js
+++ b/src/sync/syncHelpers.js
@@ -1,0 +1,25 @@
+// @flow
+
+import type { RawRecord, DirtyRaw } from '../RawRecord'
+
+// Returns raw record with naive solution to a conflict based on local `_changed` field
+// This is a per-column resolution algorithm. All columns that were changed locally win
+// and will be applied on top of the remote version.
+export function resolveConflict(local: RawRecord, remote: DirtyRaw): DirtyRaw {
+  // mutating code - performance-critical path
+  const resolved = {
+    ...remote,
+    _status: local._status,
+    // TODO: in Purple code resolution changes _changed to null, but is that right? i think until local changes are pushed, local changes are NOT synced. if pull succeeded, but push failed, this param change would get lost
+    _changed: local._changed,
+  }
+  // TODO: Doesn't raw sanitization prohibit null? (if so, also change addToRawSet; if not, add test)
+  const localChanges = (local._changed || '').split(',')
+
+  localChanges.forEach(column => {
+    resolved[column] = local[column]
+  })
+
+  // TODO: What about last_modified?
+  return resolved
+}

--- a/src/sync/test.js
+++ b/src/sync/test.js
@@ -1,0 +1,29 @@
+import { addToRawSet, setRawColumnChange } from './helpers'
+
+describe('addToRawSet', () => {
+  it('transforms raw set', () => {
+    expect(addToRawSet('', 'foo')).toBe('foo')
+    expect(addToRawSet('foo', 'bar')).toBe('foo,bar')
+    expect(addToRawSet('foo,bar', 'baz')).toBe('foo,bar,baz')
+    expect(addToRawSet('foo,bar', 'foo')).toBe('foo,bar')
+    expect(addToRawSet('foo,bar', 'bar')).toBe('foo,bar')
+    expect(addToRawSet(null, 'bar')).toBe('bar')
+  })
+})
+
+describe('setRawColumnChange', () => {
+  it('adds to _changed if needed', () => {
+    const test = (input, column, output) => {
+      const raw = { ...input }
+      setRawColumnChange(raw, column)
+      expect(raw).toEqual(output)
+    }
+    test({ _status: 'synced', _changed: '' }, 'foo', { _status: 'updated', _changed: 'foo' })
+    test({ _status: 'created', _changed: '' }, 'foo', { _status: 'created', _changed: '' })
+    test({ _status: 'updated', _changed: '' }, 'foo', { _status: 'updated', _changed: 'foo' })
+    test({ _status: 'updated', _changed: 'foo,bar' }, 'bar', {
+      _status: 'updated',
+      _changed: 'foo,bar',
+    })
+  })
+})

--- a/src/sync/test.js
+++ b/src/sync/test.js
@@ -1,4 +1,5 @@
 import { addToRawSet, setRawColumnChange } from './helpers'
+import { resolveConflict } from './syncHelpers'
 
 describe('addToRawSet', () => {
   it('transforms raw set', () => {
@@ -25,5 +26,22 @@ describe('setRawColumnChange', () => {
       _status: 'updated',
       _changed: 'foo,bar',
     })
+  })
+})
+
+describe('Conflict resolution', () => {
+  it('can resolve per-column conflicts', () => {
+    expect(
+      resolveConflict(
+        { col1: 'a', col2: true, col3: 10, _status: 'updated', _changed: 'col2' },
+        { col1: 'b', col2: false, col3: 10 },
+      ),
+    ).toEqual({ _status: 'updated', _changed: 'col2', col1: 'b', col2: true, col3: 10 })
+    expect(
+      resolveConflict(
+        { col1: 'a', col2: true, col3: 20, _status: 'updated', _changed: 'col2,col3' },
+        { col1: 'b', col2: false, col3: 10 },
+      ),
+    ).toEqual({ _status: 'updated', _changed: 'col2,col3', col1: 'b', col2: true, col3: 20 })
   })
 })


### PR DESCRIPTION
Some basic preparation/clean up for sync primitives:

- move existing helpers around + add tests
- add basic sync helper (unused yet) + tests