### PR TITLE
Sync primitives — Part 2

### DIFF
--- a/src/Database/test.js
+++ b/src/Database/test.js
@@ -27,7 +27,8 @@ describe('Database', () => {
 
 describe('Batch writes', () => {
   it('can batch records', async () => {
-    let { database, tasksCollection: collection } = mockDatabase()
+    // eslint-disable-next-line
+    let { database, cloneDatabase, tasksCollection: collection } = mockDatabase()
     const adapterBatchSpy = jest.spyOn(database.adapter, 'batch')
 
     const m1 = await collection.create()
@@ -80,11 +81,7 @@ describe('Batch writes', () => {
     expect(recordObserver).toHaveBeenCalledTimes(2)
 
     // simulate reload -- check if changes actually got saved
-    database = new Database({
-      adapter: database.adapter.testClone(),
-      schema: testSchema,
-      modelClasses: [MockTask],
-    })
+    database = cloneDatabase()
     collection = database.collections.get('mock_tasks')
 
     const fetchedM1 = await collection.find(m1.id)

--- a/src/Database/test.js
+++ b/src/Database/test.js
@@ -1,11 +1,5 @@
 import { expectToRejectWithMessage } from '../__tests__/utils'
-import {
-  mockDatabase,
-  MockProject,
-  MockTask,
-  MockComment,
-  testSchema,
-} from '../__tests__/testModels'
+import { mockDatabase, MockProject, MockTask, MockComment } from '../__tests__/testModels'
 import { noop } from '../utils/fp'
 import { CollectionChangeTypes } from '../Collection/common'
 import Database from './index'

--- a/src/__tests__/testModels.js
+++ b/src/__tests__/testModels.js
@@ -81,5 +81,13 @@ export const mockDatabase = ({ actionsEnabled = false } = {}) => {
     projectsCollection: database.collections.get('mock_projects'),
     tasksCollection: database.collections.get('mock_tasks'),
     commentsCollection: database.collections.get('mock_comments'),
+    cloneDatabase: () =>
+      // simulate reload
+      new Database({
+        adapter: database.adapter.testClone(),
+        schema: testSchema,
+        modelClasses: [MockProject, MockTask, MockComment],
+        actionsEnabled,
+      }),
   }
 }

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -1,5 +1,6 @@
 // @flow
 
+// $FlowFixMe
 import { mapAsync, promiseAllObject, map, reduce, values, pipe } from 'rambdax'
 import { unnest } from '../utils/fp'
 // import { logError } from '../utils/common'

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -1,0 +1,115 @@
+// @flow
+
+import { mapAsync, promiseAllObject, map, reduce, values, pipe } from 'rambdax'
+import { unnest } from '../utils/fp'
+// import { logError } from '../utils/common'
+import type { Database, RecordId, TableName, Collection, Model } from '..'
+import { type DirtyRaw } from '../RawRecord'
+import * as Q from '../QueryDescription'
+import { columnName } from '../Schema'
+
+import { markAsSynced } from './syncHelpers'
+
+export type SyncTableChangeSet = $Exact<{
+  created: DirtyRaw[],
+  updated: DirtyRaw[],
+  deleted: RecordId[],
+}>
+export type SyncDatabaseChangeSet = $Exact<{ [TableName<any>]: SyncTableChangeSet }>
+
+export type SyncLocalChanges = $Exact<{ changes: SyncDatabaseChangeSet, affectedRecords: Model[] }>
+
+const notSyncedQuery = Q.where(columnName('_status'), Q.notEq('synced'))
+const rawsForStatus = (status, records) =>
+  reduce(
+    (raws, record) => (record._raw._status === status ? raws.concat({ ...record._raw }) : raws),
+    [],
+    records,
+  )
+
+async function fetchLocalChangesForCollection<T: Model>(
+  collection: Collection<T>,
+): Promise<[SyncTableChangeSet, T[]]> {
+  const changedRecords = await collection.query(notSyncedQuery).fetch()
+  const changeSet = {
+    created: rawsForStatus('created', changedRecords),
+    updated: rawsForStatus('updated', changedRecords),
+    deleted: await collection.database.adapter.getDeletedRecords(collection.table),
+  }
+  return [changeSet, changedRecords]
+}
+
+const extractChanges = map(([changeSet]) => changeSet)
+const extractAllAffectedRecords = pipe(
+  values,
+  map(([, records]) => records),
+  unnest,
+)
+
+export function fetchLocalChanges(db: Database): Promise<SyncLocalChanges> {
+  return db.action(async () => {
+    const changes = await promiseAllObject(
+      map(
+        fetchLocalChangesForCollection,
+        // $FlowFixMe
+        db.collections.map,
+      ),
+    )
+    return {
+      // $FlowFixMe
+      changes: extractChanges(changes),
+      affectedRecords: extractAllAffectedRecords(changes),
+    }
+  })
+}
+
+const recordsForRaws = (raws, recordCache) =>
+  reduce(
+    (records, raw) => {
+      const record = recordCache.find(model => model.id === raw.id)
+      if (record) {
+        return records.concat(record)
+      }
+
+      // TODO: Log error
+      return records
+    },
+    [],
+    raws,
+  )
+
+export function markLocalChangesAsSyncedForCollection<T: Model>(
+  collection: Collection<T>,
+  syncedLocalChanges: SyncTableChangeSet,
+  cachedRecords: Model[],
+): Promise<void> {
+  const { database } = collection
+  return database.action(async () => {
+    const { created, updated, deleted } = syncedLocalChanges
+
+    await database.adapter.destroyDeletedRecords(collection.table, deleted)
+    const syncedRecords = recordsForRaws([...created, ...updated], cachedRecords)
+    await database.batch(...syncedRecords.map(record => record.prepareUpdate(markAsSynced)))
+  })
+}
+
+export function markLocalChangesAsSynced(
+  db: Database,
+  syncedLocalChanges: SyncLocalChanges,
+): Promise<void> {
+  return db.action(async action => {
+    // TODO: Does the order of collections matter? Should they be done one by one? Or all at once?
+    const { changes: localChanges, affectedRecords } = syncedLocalChanges
+    await mapAsync(
+      (changes, tableName) =>
+        action.subAction(() =>
+          markLocalChangesAsSyncedForCollection(
+            db.collections.get(tableName),
+            changes,
+            affectedRecords,
+          ),
+        ),
+      localChanges,
+    )
+  })
+}

--- a/src/sync/syncHelpers.js
+++ b/src/sync/syncHelpers.js
@@ -1,6 +1,7 @@
 // @flow
 
-import type { RawRecord, DirtyRaw } from '../RawRecord'
+import type { Model, Collection } from '..'
+import { type RawRecord, type DirtyRaw, sanitizedRaw } from '../RawRecord'
 
 // Returns raw record with naive solution to a conflict based on local `_changed` field
 // This is a per-column resolution algorithm. All columns that were changed locally win
@@ -22,4 +23,19 @@ export function resolveConflict(local: RawRecord, remote: DirtyRaw): DirtyRaw {
 
   // TODO: What about last_modified?
   return resolved
+}
+
+function replaceRaw(record: Model, dirtyRaw: DirtyRaw): void {
+  record._raw = sanitizedRaw(dirtyRaw, record.collection.schema)
+}
+
+export function prepareCreateFromRaw<T: Model>(collection: Collection<T>, dirtyRaw: DirtyRaw): T {
+  return collection.prepareCreate(record => {
+    replaceRaw(record, dirtyRaw)
+  })
+}
+
+export function markAsSynced(record: Model): void {
+  record._raw._status = 'synced'
+  record._raw._changed = ''
 }

--- a/src/sync/test.js
+++ b/src/sync/test.js
@@ -1,5 +1,9 @@
+import clone from 'lodash.clonedeep'
+import { mockDatabase } from '../__tests__/testModels'
+
+import { fetchLocalChanges, markLocalChangesAsSynced } from './index'
 import { addToRawSet, setRawColumnChange } from './helpers'
-import { resolveConflict } from './syncHelpers'
+import { resolveConflict, prepareCreateFromRaw } from './syncHelpers'
 
 describe('addToRawSet', () => {
   it('transforms raw set', () => {
@@ -43,5 +47,186 @@ describe('Conflict resolution', () => {
         { col1: 'b', col2: false, col3: 10 },
       ),
     ).toEqual({ _status: 'updated', _changed: 'col2,col3', col1: 'b', col2: true, col3: 20 })
+  })
+})
+
+const emptyLocalChanges = Object.freeze({
+  mock_projects: { created: [], updated: [], deleted: [] },
+  mock_tasks: { created: [], updated: [], deleted: [] },
+  mock_comments: { created: [], updated: [], deleted: [] },
+})
+
+const makeLocalChanges = async mock => {
+  const { database, projectsCollection, tasksCollection, commentsCollection } = mock
+
+  // create records
+  const p1created = prepareCreateFromRaw(projectsCollection, {})
+  const p2created = prepareCreateFromRaw(projectsCollection, {})
+  const p3updated = prepareCreateFromRaw(projectsCollection, {
+    id: 'updated1',
+    _status: 'synced',
+  })
+  const p4deleted = prepareCreateFromRaw(projectsCollection, {})
+  const t1created = prepareCreateFromRaw(tasksCollection, {})
+  const t2deleted = prepareCreateFromRaw(tasksCollection, { id: 'tsynced1', _status: 'synced' })
+  const c1created = prepareCreateFromRaw(commentsCollection, {})
+  const c2destroyed = prepareCreateFromRaw(commentsCollection, {})
+
+  await database.batch(
+    p1created,
+    p2created,
+    prepareCreateFromRaw(projectsCollection, { _status: 'synced', id: 'synced1' }),
+    p3updated,
+    p4deleted,
+    t1created,
+    prepareCreateFromRaw(tasksCollection, { _status: 'synced', id: 'synced2' }),
+    t2deleted,
+    c1created,
+    c2destroyed,
+  )
+
+  // update records
+  await p3updated.update(p => {
+    p.name = 'x'
+  })
+  await t2deleted.update(t => {
+    t.name = 'yy'
+  })
+
+  // delete records
+  await p4deleted.markAsDeleted()
+  await t2deleted.markAsDeleted()
+  await c2destroyed.destroyPermanently() // sanity check
+
+  return {
+    p1created,
+    p2created,
+    p3updated,
+    p4deleted,
+    t1created,
+    t2deleted,
+    c1created,
+  }
+}
+
+describe('fetchLocalChanges', () => {
+  it('returns empty object if no changes', async () => {
+    const { database } = mockDatabase({ actionsEnabled: true })
+    expect(await fetchLocalChanges(database)).toEqual({
+      changes: emptyLocalChanges,
+      affectedRecords: [],
+    })
+  })
+  it('fetches all local changes', async () => {
+    const mock = mockDatabase()
+    // eslint-disable-next-line
+    let { database, cloneDatabase } = mock
+
+    const {
+      p1created,
+      p2created,
+      p3updated,
+      p4deleted,
+      t1created,
+      t2deleted,
+      c1created,
+    } = await makeLocalChanges(mock)
+
+    // check
+    expect(p1created._raw._status).toBe('created')
+    expect(p3updated._raw._status).toBe('updated')
+    expect(p3updated._raw._changed).toBe('name')
+    expect(t2deleted._raw._status).toBe('deleted')
+    const expectedChanges = clone({
+      mock_projects: {
+        created: [p1created._raw, p2created._raw],
+        updated: [p3updated._raw],
+        deleted: [p4deleted.id],
+      },
+      mock_tasks: { created: [t1created._raw], updated: [], deleted: [t2deleted.id] },
+      mock_comments: {
+        created: [c1created._raw],
+        updated: [],
+        deleted: [],
+      },
+    })
+    const expectedAffectedRecords = [p1created, p2created, p3updated, t1created, c1created]
+    const result = await fetchLocalChanges(database)
+    expect(result.changes).toEqual(expectedChanges)
+    expect(result.affectedRecords).toEqual(expectedAffectedRecords)
+
+    // simulate reload
+    database = cloneDatabase()
+    const result2 = await fetchLocalChanges(database)
+    expect(result2.changes).toEqual(expectedChanges)
+    expect(result2.affectedRecords.map(r => r._raw)).toEqual(
+      expectedAffectedRecords.map(r => r._raw),
+    )
+  })
+  it('returns object copies', async () => {
+    const mock = mockDatabase()
+    const { database } = mock
+
+    const { p3updated } = await makeLocalChanges(mock)
+
+    const { changes } = await fetchLocalChanges(database)
+    const changesCloned = clone(changes)
+
+    // raws should be cloned - further changes don't affect result
+    await p3updated.update(p => {
+      p.name = 'y'
+    })
+    expect(changes).toEqual(changesCloned)
+  })
+})
+
+describe('markLocalChangesAsSynced', () => {
+  it('does nothing for empty local changes', async () => {
+    const mock = mockDatabase()
+    const { database } = mock
+
+    await makeLocalChanges(mock)
+    const localChanges1 = await fetchLocalChanges(database)
+
+    await markLocalChangesAsSynced(database, emptyLocalChanges)
+
+    const localChanges2 = await fetchLocalChanges(database)
+    expect(localChanges1).toEqual(localChanges2)
+  })
+  it('marks local changes as synced', async () => {
+    const mock = mockDatabase()
+    const { database, adapter, projectsCollection, tasksCollection } = mock
+
+    await makeLocalChanges(mock)
+
+    const projectCount = await projectsCollection.query().fetchCount()
+    const taskCount = await tasksCollection.query().fetchCount()
+
+    const localChanges = await fetchLocalChanges(database)
+    await markLocalChangesAsSynced(database, localChanges)
+
+    // no more changes
+    expect((await fetchLocalChanges(database)).changes).toEqual(emptyLocalChanges)
+
+    // still just as many objects
+    const projects = await projectsCollection.query().fetch()
+    const tasks = await tasksCollection.query().fetch()
+    expect(projects.length).toBe(projectCount)
+    expect(tasks.length).toBe(taskCount)
+
+    // all objects marked as synced
+    expect(projects.every(record => record.syncStatus === 'synced')).toBe(true)
+    expect(tasks.every(record => record.syncStatus === 'synced')).toBe(true)
+
+    // no objects marked as deleted
+    expect(await adapter.getDeletedRecords('mock_projects')).toEqual([])
+    expect(await adapter.getDeletedRecords('mock_tasks')).toEqual([])
+    expect(await adapter.getDeletedRecords('mock_comments')).toEqual([])
+  })
+  it.skip('only emits one collection batch change', async () => {
+    // TODO
+  })
+  it.skip(`doesn't mark as synced records that changed since changes were fetched`, async () => {
+    // TODO
   })
 })

--- a/src/sync/test.js
+++ b/src/sync/test.js
@@ -206,7 +206,10 @@ describe('markLocalChangesAsSynced', () => {
     await markLocalChangesAsSynced(database, localChanges)
 
     // no more changes
-    expect((await fetchLocalChanges(database)).changes).toEqual(emptyLocalChanges)
+    expect(await fetchLocalChanges(database)).toEqual({
+      changes: emptyLocalChanges,
+      affectedRecords: [],
+    })
 
     // still just as many objects
     const projects = await projectsCollection.query().fetch()


### PR DESCRIPTION
Adds two building blocks necessary for sync:

- function for fetching local changes (that need to be pushed to the server to sync)
- function for marking local changes as synced (after server acknowledges it has the new data)
- tests

Those are not the best/prettiest/most performant implementations ever — I will continue tweaking it in future PRs. I don't want to spend too much time refactoring this code yet, because I might have to completely redo it as I understand all the intricacies of sync.