### PR TITLE
[WIP] Sync primitives - Part 5

### DIFF
--- a/src/__tests__/testModels.js
+++ b/src/__tests__/testModels.js
@@ -1,5 +1,5 @@
 import { appSchema, tableSchema } from '../Schema'
-import { field, relation, immutableRelation, text } from '../decorators'
+import { field, relation, immutableRelation, text, readonly, date } from '../decorators'
 import Model from '../Model'
 import Database from '../Database'
 import LokiJSAdapter from '../adapters/lokijs'
@@ -23,7 +23,12 @@ export const testSchema = appSchema({
     }),
     tableSchema({
       name: 'mock_comments',
-      columns: [{ name: 'task_id', type: 'string' }, { name: 'body', type: 'string' }],
+      columns: [
+        { name: 'task_id', type: 'string' },
+        { name: 'body', type: 'string' },
+        { name: 'created_at', type: 'number' },
+        { name: 'updated_at', type: 'number' },
+      ],
     }),
   ],
 })
@@ -65,6 +70,14 @@ export class MockComment extends Model {
 
   @text('body')
   body
+
+  @readonly
+  @date('created_at')
+  createdAt
+
+  @readonly
+  @date('updated_at')
+  updatedAt
 }
 
 export const mockDatabase = ({ actionsEnabled = false } = {}) => {

--- a/src/sync/syncHelpers.js
+++ b/src/sync/syncHelpers.js
@@ -59,8 +59,8 @@ export function prepareUpdateFromRaw<T: Model>(record: T, updatedDirtyRaw: Dirty
 }
 
 export function prepareMarkAsSynced<T: Model>(record: T): T {
+  const newRaw = { ...record._raw, _status: 'synced', _changed: '' }
   return record.prepareUpdate(() => {
-    record._raw._status = 'synced'
-    record._raw._changed = ''
+    replaceRaw(record, newRaw)
   })
 }

--- a/src/sync/test.js
+++ b/src/sync/test.js
@@ -386,9 +386,8 @@ describe('applyRemoteChanges', () => {
           { id: 'tSynced', name: 'remote' },
           // create / updated - resolve and update (stay updated)
           { id: 'tUpdated', name: 'remote', description: 'remote' },
-          // FIXME:
           // create / deleted - destroy and recreate? (or just un-delete?)
-          // { id: 'tDeleted', name: 'remote' },
+          { id: 'tDeleted', name: 'remote' },
         ],
         updated: [],
         deleted: [],
@@ -403,8 +402,7 @@ describe('applyRemoteChanges', () => {
       description: 'remote', // remote change
       project_id: 'orig', // unchanged
     })
-    // FIXME:
-    // await expectSyncedAndMatches(tasks, 'tDeleted', { name: 'remote' })
+    await expectSyncedAndMatches(tasks, 'tDeleted', { name: 'remote' })
   })
   it('can handle weird edge cases', async () => {
     const mock = mockDatabase()

--- a/src/sync/test.js
+++ b/src/sync/test.js
@@ -268,12 +268,12 @@ describe('markLocalChangesAsSynced', () => {
     const { database, comments } = mock
 
     await makeLocalChanges(mock)
+    const updatedAt = (await getRaw(comments, 'cUpdated')).updated_at
     await markLocalChangesAsSynced(database, await fetchLocalChanges(database))
 
-    const timestamps = { created_at: 1000, updated_at: 2000 }
-    await expectSyncedAndMatches(comments, 'cCreated', timestamps)
-    await expectSyncedAndMatches(comments, 'cUpdated', timestamps)
-    await expectSyncedAndMatches(comments, 'cSynced', timestamps)
+    await expectSyncedAndMatches(comments, 'cCreated', { created_at: 1000, updated_at: 2000 })
+    await expectSyncedAndMatches(comments, 'cUpdated', { created_at: 1000, updated_at: updatedAt })
+    await expectSyncedAndMatches(comments, 'cSynced', { created_at: 1000, updated_at: 2000 })
   })
   it.skip('only emits one collection batch change', async () => {
     // TODO


### PR DESCRIPTION
- Fixes an issue where `create` server changes wouldn't get applied if record is locally mistakenly marked as `deleted`
- Fixes issues relating to automating updated_at/created_at timestamps