### PR TITLE
Sync primitives — Part 7

### DIFF
--- a/src/sync/impl.js
+++ b/src/sync/impl.js
@@ -132,7 +132,7 @@ function prepareApplyRemoteChangesToCollection<T: Model>(
   }, updated)
 
   // $FlowFixMe
-  return [...recordsToInsert, ...recordsToUpdate.filter(Boolean)]
+  return [...recordsToInsert, ...filter(Boolean, recordsToUpdate)]
 }
 
 const getAllRecordsToApply = (db: Database, remoteChanges: SyncDatabaseChangeSet) =>

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -10,6 +10,7 @@ import {
   markLocalChangesAsSynced,
   getLastSyncedAt,
   setLastSyncedAt,
+  ensureActionsEnabled,
 } from './impl'
 
 export type Timestamp = number
@@ -35,6 +36,8 @@ export type SyncArgs = $Exact<{
 }>
 
 export async function synchronize({ database, pullChanges, pushChanges }: SyncArgs): Promise<void> {
+  ensureActionsEnabled(database)
+
   // pull phase
   const lastSyncedAt = await getLastSyncedAt(database)
   const { changes: remoteChanges, timestamp } = await pullChanges({ lastSyncedAt })


### PR DESCRIPTION
- Forces Actions to be enabled in Watermelon to use Sync (otherwise it's unsafe)
- Makes applyRemoteChanges faster: it now runs more concurrently, and updates/creates are in one big batch
   - sadly, it makes code a lot harder to follow :( … but it's the best I came up with so far
   - refactor ideas appreciated ❤️ 