### PR TITLE
Remove last_modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   ```
   { name: 'last_modified', type: 'number', isOptional: true }
   ```
+  *Don't* bump schema version or write a migration for this.
 
 ### New
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Breaking
+
+- BREAKING: Table column `last_modified` is no longer automatically added to all database tables. If
+  you don't use this column (e.g. in your custom sync code), you don't have to do anything.
+  If you do, manually add this column to all table definitions in your Schema:
+  ```
+  { name: 'last_modified', type: 'number', isOptional: true }
+  ```
+
 ### New
 
 - [WIP] Sync primitives

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nozbe/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "0.9.0",
+  "version": "0.10.0-0",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/src/Model/test.js
+++ b/src/Model/test.js
@@ -112,7 +112,6 @@ describe('CRUD', () => {
       id: m1.id,
       _status: 'created',
       _changed: '',
-      last_modified: null,
       name: 'Some name',
       otherfield: '',
       col3: '',

--- a/src/RawRecord/index.js
+++ b/src/RawRecord/index.js
@@ -18,7 +18,6 @@ type _RawRecord = {
   id: RecordId,
   _status: SyncStatus,
   _changed: string,
-  last_modified: number | null,
 }
 
 // Raw object representing a model record. A RawRecord is guaranteed by the type system
@@ -70,7 +69,7 @@ function isValidStatus(value: any): boolean {
 
 // Transforms a dirty raw record object into a trusted sanitized RawRecord according to passed TableSchema
 export function sanitizedRaw(dirtyRaw: DirtyRaw, tableSchema: TableSchema): RawRecord {
-  const { id, _status, _changed, last_modified: lastModified } = dirtyRaw
+  const { id, _status, _changed } = dirtyRaw
 
   // This is called with `{}` when making a new record, so we need to set a new ID, status
   // Also: If an existing has one of those fields broken, we're screwed. Safest to treat it as a
@@ -81,12 +80,10 @@ export function sanitizedRaw(dirtyRaw: DirtyRaw, tableSchema: TableSchema): RawR
     raw.id = id
     raw._status = isValidStatus(_status) ? _status : 'created'
     raw._changed = typeof _changed === 'string' ? _changed : ''
-    raw.last_modified = isValidNumber(lastModified) ? lastModified : null
   } else {
     raw.id = randomId()
     raw._status = 'created'
     raw._changed = ''
-    raw.last_modified = null
   }
 
   values(tableSchema.columns).forEach(columnSchema => {

--- a/src/RawRecord/test.js
+++ b/src/RawRecord/test.js
@@ -57,7 +57,6 @@ describe('sanitizedRaw()', () => {
       id: 'abcdef',
       _status: 'synced',
       _changed: '',
-      last_modified: 1532612920392,
       name: 'My task',
       responsible_id: 'abcdef',
       created_at: 1632612920392,
@@ -75,7 +74,6 @@ describe('sanitizedRaw()', () => {
       id: 'abcdef2',
       _status: 'updated',
       _changed: 'foo,bar',
-      last_modified: 1332612920392,
       name: 'My task 2',
       responsible_id: null,
       created_at: 1432612920392,
@@ -92,7 +90,7 @@ describe('sanitizedRaw()', () => {
       id: 'abcdef3',
       _status: 'created',
       _changed: null,
-      last_modified: 1000 /* .1 */,
+      last_modified: 1000 /* .1 */, // last_modified was removed
       name: '',
       created_at: 2018 /* .5 */,
       ended_at: 'NaN',
@@ -105,7 +103,6 @@ describe('sanitizedRaw()', () => {
       id: 'abcdef3',
       _status: 'created',
       _changed: '',
-      last_modified: 1000,
       name: '',
       responsible_id: null,
       created_at: 2018,
@@ -116,12 +113,11 @@ describe('sanitizedRaw()', () => {
       is_all_day: null,
     })
   })
-  it('can create a valid raw from nothin', () => {
+  it(`can create a valid raw from nothin'`, () => {
     const newRaw = sanitizedRaw({}, mockTaskSchema)
     expect(omit(['id'], newRaw)).toEqual({
       _status: 'created',
       _changed: '',
-      last_modified: null,
       name: '',
       responsible_id: null,
       created_at: 0,
@@ -134,7 +130,7 @@ describe('sanitizedRaw()', () => {
     expect(typeof newRaw.id).toBe('string')
     expect(newRaw.id).toHaveLength(16)
   })
-  it('sanitizes id, _status, _changed, last_modified', () => {
+  it('sanitizes id, _status, _changed', () => {
     const schema2 = tableSchema({ name: 'test2', columns: [] })
 
     const validateId = raw => {
@@ -143,29 +139,20 @@ describe('sanitizedRaw()', () => {
     }
 
     // if ID is missing or malformed, treat this as a new object
-    const raw1 = sanitizedRaw({ _status: 'updated', _changed: 'a,b', last_modified: 1234 }, schema2)
-    expect(omit(['id'], raw1)).toEqual({ _status: 'created', _changed: '', last_modified: null })
+    const raw1 = sanitizedRaw({ _status: 'updated', _changed: 'a,b' }, schema2)
+    expect(omit(['id'], raw1)).toEqual({ _status: 'created', _changed: '' })
     validateId(raw1)
 
-    const raw2 = sanitizedRaw(
-      { id: null, _status: 'updated', _changed: 'a,b', last_modified: 1234 },
-      schema2,
-    )
-    expect(omit(['id'], raw2)).toEqual({ _status: 'created', _changed: '', last_modified: null })
+    const raw2 = sanitizedRaw({ id: null, _status: 'updated', _changed: 'a,b' }, schema2)
+    expect(omit(['id'], raw2)).toEqual({ _status: 'created', _changed: '' })
     validateId(raw2)
 
     // otherwise, just sanitize other fields
-    const raw3 = sanitizedRaw(
-      { id: 'i1', _status: '', _changed: 'a,b', last_modified: 1234 },
-      schema2,
-    )
-    expect(raw3).toEqual({ id: 'i1', _status: 'created', _changed: 'a,b', last_modified: 1234 })
+    const raw3 = sanitizedRaw({ id: 'i1', _status: '', _changed: 'a,b' }, schema2)
+    expect(raw3).toEqual({ id: 'i1', _status: 'created', _changed: 'a,b' })
 
-    const raw4 = sanitizedRaw(
-      { id: 'i2', _status: 'deleted', _changed: true, last_modified: NaN },
-      schema2,
-    )
-    expect(raw4).toEqual({ id: 'i2', _status: 'deleted', _changed: '', last_modified: null })
+    const raw4 = sanitizedRaw({ id: 'i2', _status: 'deleted', _changed: true }, schema2)
+    expect(raw4).toEqual({ id: 'i2', _status: 'deleted', _changed: '' })
   })
 })
 

--- a/src/Schema/index.js
+++ b/src/Schema/index.js
@@ -60,13 +60,19 @@ export function validateColumnSchema(column: ColumnSchema): void {
       `Invalid type ${column.type} for column ${column.name} (valid: string, boolean, number)`,
     )
     invariant(
-      !contains(column.name, ['id', 'last_modified', '_changed', '_status']),
-      `You must not define columns with name ${column.name}`,
+      !contains(column.name, ['id', '_changed', '_status']),
+      `You must not define a column with name ${column.name}`,
     )
     if (column.name === 'created_at' || column.name === 'updated_at') {
       invariant(
         column.type === 'number' && !column.isOptional,
         `${column.name} must be of type number and not optional`,
+      )
+    }
+    if (column.name === 'last_modified') {
+      invariant(
+        column.type === 'number',
+        `For compatibility reasons, column last_modified must be of type 'number', and should be optional`,
       )
     }
   }

--- a/src/Schema/test.js
+++ b/src/Schema/test.js
@@ -1,6 +1,6 @@
 import { appSchema, tableSchema } from './index'
 
-describe('watermelondb/Schema', () => {
+describe('Schema', () => {
   it('can prepare schema', () => {
     const testSchema = appSchema({
       version: 1,
@@ -40,5 +40,25 @@ describe('watermelondb/Schema', () => {
         },
       },
     })
+  })
+  it('can define last_modified in user land', () => {
+    expect(() =>
+      tableSchema({
+        name: 'foo',
+        columns: [{ name: 'last_modified', type: 'number', isOptional: true }],
+      }),
+    ).not.toThrow()
+    expect(() =>
+      tableSchema({
+        name: 'foo',
+        columns: [{ name: 'last_modified', type: 'number' }],
+      }),
+    ).not.toThrow()
+    expect(() =>
+      tableSchema({
+        name: 'foo',
+        columns: [{ name: 'last_modified', type: 'string' }],
+      }),
+    ).toThrow(/last_modified must be.*number/)
   })
 })

--- a/src/adapters/sqlite/encodeSchema/index.js
+++ b/src/adapters/sqlite/encodeSchema/index.js
@@ -13,7 +13,7 @@ import type { SQL } from '../index'
 import encodeName from '../encodeName'
 import encodeValue from '../encodeValue'
 
-const standardColumns = `"id" primary key, "_changed", "_status", "last_modified"`
+const standardColumns = `"id" primary key, "_changed", "_status"`
 
 const encodeCreateTable: TableSchema => SQL = ({ name, columns }) => {
   const columnsSQL = [standardColumns]

--- a/src/adapters/sqlite/encodeSchema/test.js
+++ b/src/adapters/sqlite/encodeSchema/test.js
@@ -24,11 +24,11 @@ describe('encodeSchema', () => {
     })
 
     const expectedSchema =
-      'create table "tasks" ("id" primary key, "_changed", "_status", "last_modified", "author_id", "order", "created_at");' +
+      'create table "tasks" ("id" primary key, "_changed", "_status", "author_id", "order", "created_at");' +
       'create index tasks_author_id on "tasks" ("author_id");' +
       'create index tasks_order on "tasks" ("order");' +
       'create index tasks__status on "tasks" ("_status");' +
-      'create table "comments" ("id" primary key, "_changed", "_status", "last_modified", "is_ended", "reactions");' +
+      'create table "comments" ("id" primary key, "_changed", "_status", "is_ended", "reactions");' +
       'create index comments__status on "comments" ("_status");'
 
     expect(encodeSchema(testSchema)).toBe(expectedSchema)
@@ -58,7 +58,7 @@ describe('encodeSchema', () => {
     const expectedSQL =
       `alter table "posts" add "subtitle";` +
       `update "posts" set "subtitle" = null;` +
-      `create table "comments" ("id" primary key, "_changed", "_status", "last_modified", "post_id", "body");` +
+      `create table "comments" ("id" primary key, "_changed", "_status", "post_id", "body");` +
       `create index comments_post_id on "comments" ("post_id");` +
       `create index comments__status on "comments" ("_status");` +
       `alter table "posts" add "author_id";` +


### PR DESCRIPTION
We don't actually need `last_modified` for our new sync implementation. Some people might, but there's no reason why it should be built in if one can just define it in app schema.