### PR TITLE
Fix @date getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changes
+
+- ⚠️ Potentially BREAKING fix: a `@date` field now returns a Jan 1, 1970 date instead of `null` if the field's raw value is `0`.
+   This is considered a bug fix, since it's unexpected to receive a `null` from a getter of a field whose column schema doesn't say `isOptional: true`.
+   However, if you relied on this behavior, this might be a breaking change.
+
 ## 0.10.1 - 2019-02-12
 
 ### Changes

--- a/src/decorators/date/index.js
+++ b/src/decorators/date/index.js
@@ -24,7 +24,7 @@ const dateDecorator = makeDecorator(
       enumerable: true,
       get(): ?Date {
         const rawValue = this._getRaw(columnName)
-        return rawValue ? new Date(rawValue) : null
+        return typeof rawValue === 'number' ? new Date(rawValue) : null
       },
       set(date: ?Date): void {
         const rawValue = date ? +new Date(date) : null

--- a/src/decorators/date/test.js
+++ b/src/decorators/date/test.js
@@ -37,6 +37,18 @@ describe('decorators/timestamp', () => {
     model.date = null
     expect(model._getRaw('date')).toBe(null)
   })
+  it('returns 1970 date, not null if timestamp=0', () => {
+    const model = new MockModel({ schema }, { date: 0 })
+    expect(model.date).toBeInstanceOf(Date)
+    expect(+model.date).toBe(0)
+  })
+  it('sets 1970 date, not null if timestamp', () => {
+    const model = new MockModel({ schema }, {})
+    model._isEditing = true
+    model.date = new Date(0)
+    expect(model._getRaw('date')).toBe(0)
+    expect(+model.date).toBe(0)
+  })
   it('fails if applied to incorrect fields', () => {
     expect(
       () =>


### PR DESCRIPTION
`@date` field now returns a Jan 1, 1970 date instead of `null` if the field's raw value is `0`.