### PR TITLE
Update Actions.md

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -14,8 +14,8 @@ import { action } from '@nozbe/watermelondb/decorators'
 class Post extends Model {
   // ...
 
-  @action async addComment(body, author) {
-    return await this.collections.get('comments').create(comment => {
+  @action addComment(body, author) {
+    return this.collections.get('comments').create(comment => {
       comment.post.set(this)
       comment.author.set(author)
       comment.body = body
@@ -36,8 +36,8 @@ class Comment extends Model {
   // ...
   @field('is_spam') isSpam
 
-  @action async markAsSpam() {
-    await this.update(comment => {
+  @action markAsSpam() {
+    return this.update(comment => {
       comment.isSpam = true
     })
   }


### PR DESCRIPTION
As speciefied in https://eslint.org/docs/rules/no-return-await `Inside an async function, return await is seldom useful. Since the return value of an async function is always wrapped in Promise.resolve, return await doesn’t actually do anything except add extra time before the overarching Promise resolves or rejects. The only valid exception is if return await is used in a try/catch statement to catch errors from another Promise-based function.`

Or maybe no return at all?