### PR TITLE
Fix crash on running db.unsafeResetDatabase() without an action

### DIFF
--- a/examples/native/src/models/generate.js
+++ b/examples/native/src/models/generate.js
@@ -35,7 +35,7 @@ const makeComment = (db, post, i) =>
 const makeComments = (db, post, count) => times(i => makeComment(db, post, i), count)
 
 const generate = async (db, blogCount, postsPerBlog, commentsPerPost) => {
-  await db.unsafeResetDatabase()
+  await db.action(() => db.unsafeResetDatabase())
   const blogs = times(i => makeBlog(db, i), blogCount)
   const posts = flatMap(blog => makePosts(db, blog, fuzzCount(postsPerBlog)), blogs)
   const comments = flatMap(post => makeComments(db, post, fuzzCount(commentsPerPost)), posts)

--- a/examples/web/src/models/generate.js
+++ b/examples/web/src/models/generate.js
@@ -35,7 +35,7 @@ const makeComment = (db, post, i) =>
 const makeComments = (db, post, count) => times(i => makeComment(db, post, i), count)
 
 const generate = async (db, blogCount, postsPerBlog, commentsPerPost) => {
-  await db.unsafeResetDatabase()
+  await db.action(() => db.unsafeResetDatabase())
   const blogs = times(i => makeBlog(db, i), blogCount)
   const posts = flatMap(blog => makePosts(db, blog, fuzzCount(postsPerBlog)), blogs)
   const comments = flatMap(post => makeComments(db, post, fuzzCount(commentsPerPost)), posts)


### PR DESCRIPTION
Because of the breaking change in 0.10.2-1 we need to run `db.unsafeResetDatabase` inside an action.
This fixed #281