### PR TITLE
[decorators] Make them work on other objects than Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changes
+
+- **Decorators**. You can now use `@action` on methods of any object that has a `database: Database`
+     property, and `@field @children @date @relation @immutableRelation @json @text @nochange` decorators on
+     any object with a `asModel: Model` property.
+
 ## 0.12.1 - 2019-04-01
 
 ### ⚠️ Hotfix

--- a/src/Model/index.js
+++ b/src/Model/index.js
@@ -12,6 +12,7 @@ import type { $RE } from '../types'
 import field from '../decorators/field'
 import readonly from '../decorators/readonly'
 
+import type Database from '../Database'
 import type Collection from '../Collection'
 import type CollectionMap from '../Database/CollectionMap'
 import { type TableName, type ColumnName, columnName } from '../Schema'
@@ -154,7 +155,15 @@ export default class Model {
 
   // Collections of other Models in the same domain as this record
   get collections(): CollectionMap {
-    return this.collection.database.collections
+    return this.database.collections
+  }
+
+  get database(): Database {
+    return this.collection.database
+  }
+
+  get asModel(): this {
+    return this
   }
 
   // See: Database.batch()

--- a/src/__tests__/testModels.js
+++ b/src/__tests__/testModels.js
@@ -43,23 +43,17 @@ export class MockProject extends Model {
 export class MockTask extends Model {
   static table = 'mock_tasks'
 
-  @field('name')
-  name
+  @field('name') name
 
-  @field('position')
-  position
+  @field('position') position
 
-  @field('is_completed')
-  isCompleted
+  @field('is_completed') isCompleted
 
-  @field('description')
-  description
+  @field('description') description
 
-  @field('project_id')
-  projectId
+  @field('project_id') projectId
 
-  @relation('mock_projects', 'project_id')
-  project
+  @relation('mock_projects', 'project_id') project
 }
 
 export class MockComment extends Model {

--- a/src/decorators/action/index.js
+++ b/src/decorators/action/index.js
@@ -2,13 +2,14 @@
 
 import type { Descriptor } from '../../utils/common/makeDecorator'
 
-// TODO: Document me
+// Wraps function calls in `database.action(() => { ... })`. See docs for more details
+// You can use this on Model subclass methods (or methods of any object that has a `database` property)
 export default function action(target: Object, key: string, descriptor: Descriptor): Descriptor {
   const actionName = `${target.table}.${key}`
   return {
     ...descriptor,
     value(...args): Promise<any> {
-      return this.collection.database.action(() => descriptor.value.apply(this, args), actionName)
+      return this.database.action(() => descriptor.value.apply(this, args), actionName)
     },
   }
 }

--- a/src/decorators/action/test.js
+++ b/src/decorators/action/test.js
@@ -32,4 +32,21 @@ describe('@action', () => {
 
     expect(await record.nested(1, 2, 3, 4)).toEqual(['test', 'sub', 1, [2, 3, 4]])
   })
+  it('works with arbitrary classes', async () => {
+    const { database } = mockDatabase({ actionsEnabled: true })
+    const actionSpy = jest.spyOn(database, 'action')
+    class TestClass {
+      database
+
+      @action async test() {
+        return 42
+      }
+    }
+
+    const test = new TestClass()
+    test.database = database
+
+    expect(await test.test()).toEqual(42)
+    expect(actionSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/decorators/children/index.js
+++ b/src/decorators/children/index.js
@@ -16,14 +16,7 @@ import type Query from '../../Query'
 // Example: a Task has_many Comments, so it may define:
 //   @children('comment') comments: Query<Comment>
 
-const children = makeDecorator((childTable: TableName<any>) => (target: Model) => {
-  const association = target.constructor.associations[childTable]
-
-  invariant(
-    association && association.type === 'has_many',
-    `@children decorator used for a table that's not has_many`,
-  )
-
+const children = makeDecorator((childTable: TableName<any>) => () => {
   return {
     get(): Query<Model> {
       // Use cached Query if possible
@@ -36,6 +29,13 @@ const children = makeDecorator((childTable: TableName<any>) => (target: Model) =
       // Cache new Query
       const model: Model = this.asModel
       const childCollection = model.collections.get(childTable)
+
+      const association = model.constructor.associations[childTable]
+      invariant(
+        association && association.type === 'has_many',
+        `@children decorator used for a table that's not has_many`,
+      )
+
       const query = childCollection.query(Q.where(association.foreignKey, model.id))
 
       this._childrenQueryCache[childTable] = query

--- a/src/decorators/children/index.js
+++ b/src/decorators/children/index.js
@@ -34,9 +34,9 @@ const children = makeDecorator((childTable: TableName<any>) => (target: Model) =
       }
 
       // Cache new Query
-      const that: Model = this
-      const childCollection = that.collections.get(childTable)
-      const query = childCollection.query(Q.where(association.foreignKey, that.id))
+      const model: Model = this.asModel
+      const childCollection = model.collections.get(childTable)
+      const query = childCollection.query(Q.where(association.foreignKey, model.id))
 
       this._childrenQueryCache[childTable] = query
       return query

--- a/src/decorators/children/test.js
+++ b/src/decorators/children/test.js
@@ -14,8 +14,7 @@ class MockParent extends Model {
     mock_child: { type: 'has_many', foreignKey: 'parent_id' },
   }
 
-  @children('mock_child')
-  children
+  @children('mock_child') children
 }
 
 class MockChild extends Model {
@@ -25,8 +24,7 @@ class MockChild extends Model {
     mock_parent: { type: 'belongs_to', key: 'parent_id' },
   }
 
-  @field('parent_id')
-  parentId
+  @field('parent_id') parentId
 }
 
 const makeDatabase = () =>
@@ -55,6 +53,19 @@ describe('decorators/children', () => {
       .get('mock_child')
       .query(Q.where('parent_id', parentMock.id))
     expect(parentMock.children).toEqual(expectedQuery)
+  })
+  it('works on arbitrary objects with asModel', async () => {
+    const database = makeDatabase()
+    database.adapter.batch = jest.fn()
+
+    const parent = await database.collections.get('mock_parent').create()
+    class ParentProxy {
+      asModel = parent
+
+      @children('mock_child') children
+    }
+    const parentProxy = new ParentProxy()
+    expect(parentProxy.children).toEqual(parent.children)
   })
   it('throws error if set is attempted', async () => {
     const database = makeDatabase()

--- a/src/decorators/date/index.js
+++ b/src/decorators/date/index.js
@@ -23,12 +23,12 @@ const dateDecorator = makeDecorator(
       configurable: true,
       enumerable: true,
       get(): ?Date {
-        const rawValue = this._getRaw(columnName)
+        const rawValue = this.asModel._getRaw(columnName)
         return typeof rawValue === 'number' ? new Date(rawValue) : null
       },
       set(date: ?Date): void {
         const rawValue = date ? +new Date(date) : null
-        this._setRaw(columnName, rawValue)
+        this.asModel._setRaw(columnName, rawValue)
       },
     }
   },

--- a/src/decorators/field/index.js
+++ b/src/decorators/field/index.js
@@ -25,10 +25,10 @@ const field = makeDecorator(
       configurable: true,
       enumerable: true,
       get(): Value {
-        return this._getRaw(columnName)
+        return this.asModel._getRaw(columnName)
       },
       set(value: any): void {
-        this._setRaw(columnName, value)
+        this.asModel._setRaw(columnName, value)
       },
     }
   },

--- a/src/decorators/field/test.js
+++ b/src/decorators/field/test.js
@@ -1,27 +1,38 @@
-import Model from '../../Model'
+import { MockTask, mockDatabase } from '../../__tests__/testModels'
 import field from './index'
-
-class MockModel extends Model {
-  @field('foo_bar')
-  fooBar
-}
 
 describe('decorators/field', () => {
   it('delegates accesses to _getRaw/_setRaw', () => {
-    const model = new MockModel({}, {})
+    const { tasks } = mockDatabase()
+    const model = new MockTask(tasks, {})
     model._getRaw = jest.fn()
     model._setRaw = jest.fn()
 
-    model.fooBar
-    model.fooBar = 'xx'
-    model.fooBar
-    model.fooBar = 'bar'
+    model.projectId
+    model.projectId = 'xx'
+    model.projectId
+    model.projectId = 'bar'
 
     expect(model._getRaw).toHaveBeenCalledTimes(2)
-    expect(model._getRaw).toHaveBeenCalledWith('foo_bar')
+    expect(model._getRaw).toHaveBeenCalledWith('project_id')
     expect(model._setRaw).toHaveBeenCalledTimes(2)
-    expect(model._setRaw).toHaveBeenCalledWith('foo_bar', 'xx')
-    expect(model._setRaw).toHaveBeenLastCalledWith('foo_bar', 'bar')
+    expect(model._setRaw).toHaveBeenCalledWith('project_id', 'xx')
+    expect(model._setRaw).toHaveBeenLastCalledWith('project_id', 'bar')
+  })
+  it('works with arbitrary objects with asModel', () => {
+    const { tasks } = mockDatabase()
+    const model = new MockTask(tasks, {})
+    class ModelProxy {
+      asModel = model
+
+      @field('name') name
+    }
+    model._isEditing = true
+    model.name = 'a'
+    const proxy = new ModelProxy()
+    expect(proxy.name).toBe('a')
+    proxy.name = 'b'
+    expect(model.name).toBe('b')
   })
   it('fails if applied to incorrect fields', () => {
     expect(

--- a/src/decorators/json/index.js
+++ b/src/decorators/json/index.js
@@ -36,7 +36,7 @@ export const jsonDecorator = makeDecorator(
       configurable: true,
       enumerable: true,
       get(): any {
-        const rawValue = this._getRaw(rawFieldName)
+        const rawValue = this.asModel._getRaw(rawFieldName)
         const parsedValue = parseJSON(rawValue)
 
         return sanitizer(parsedValue)
@@ -45,7 +45,7 @@ export const jsonDecorator = makeDecorator(
         const sanitizedValue = sanitizer(json)
         const stringifiedValue = sanitizedValue != null ? JSON.stringify(sanitizedValue) : null
 
-        this._setRaw(rawFieldName, stringifiedValue)
+        this.asModel._setRaw(rawFieldName, stringifiedValue)
       },
     }
   },

--- a/src/decorators/nochange/index.js
+++ b/src/decorators/nochange/index.js
@@ -19,7 +19,7 @@ const nochange = makeDecorator(() => (target: Object, key: string, descriptor: O
   return {
     ...descriptor,
     set(value: any): void {
-      invariant(!this._isCommitted, errorMessage)
+      invariant(!this.asModel._isCommitted, errorMessage)
       descriptor.set.call(this, value)
     },
   }

--- a/src/decorators/relation/index.js
+++ b/src/decorators/relation/index.js
@@ -38,7 +38,7 @@ const relation = (
       }
 
       const newRelation = new Relation(
-        this,
+        this.asModel,
         relationTable,
         relationIdColumn,
         options || { isImmutable: false },
@@ -48,7 +48,7 @@ const relation = (
       return newRelation
     },
     set(): void {
-      throw new Error('Don\'t set relation directly. Use relation.set() instead')
+      throw new Error(`Don't set relation directly. Use relation.set() instead`)
     },
   }
 }

--- a/src/decorators/relation/test.js
+++ b/src/decorators/relation/test.js
@@ -1,18 +1,28 @@
 import { MockTask, mockDatabase } from '../../__tests__/testModels'
 
+import relation from './index'
 import Relation from '../../Relation'
 
 describe('decorators/relation', () => {
   it('creates Relation object', () => {
     const { tasks } = mockDatabase()
     const primary = new MockTask(tasks, { project_id: 's1' })
-
-    const relation = primary.project
-    expect(relation).toEqual(
+    expect(primary.project).toEqual(
       new Relation(primary, 'mock_projects', 'project_id', { isImmutable: false }),
     )
   })
+  it('works on arbitrary objects with asModel', () => {
+    const { tasks } = mockDatabase()
+    const primary = new MockTask(tasks, { project_id: 's1' })
 
+    class PrimaryProxy {
+      asModel = primary
+
+      @relation('mock_projects', 'project_id') project
+    }
+    const primaryProxy = new PrimaryProxy()
+    expect(primaryProxy.project).toEqual(primary.project)
+  })
   it('disallows to set relation directly', () => {
     const { tasks } = mockDatabase()
     const primary = new MockTask(tasks, { project_id: 's1' })
@@ -21,7 +31,6 @@ describe('decorators/relation', () => {
       primary.project = 'blah'
     }).toThrow()
   })
-
   it('caches Relation object', () => {
     const { tasks } = mockDatabase()
     const primary = new MockTask(tasks, { project_id: 's1' })

--- a/src/decorators/text/index.js
+++ b/src/decorators/text/index.js
@@ -26,10 +26,10 @@ const text = makeDecorator(
       configurable: true,
       enumerable: true,
       get(): ?string {
-        return this._getRaw(columnName)
+        return this.asModel._getRaw(columnName)
       },
       set(value: ?string): void {
-        this._setRaw(columnName, typeof value === 'string' ? value.trim() : null)
+        this.asModel._setRaw(columnName, typeof value === 'string' ? value.trim() : null)
       },
     }
   },


### PR DESCRIPTION
**Decorators**. You can now use `@action` on methods of any object that has a `database: Database`
      property, and `@field @children @date @relation @immutableRelation @json @text @nochange` decorators on
      any object with a `asModel: Model` property.


This is useful for splitting huge Model classes into manageable chunks