### PR TITLE
Allow custom id generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - [TypeScript] 'Cannot use 'in' operator to search for 'initializer'; decorator fix
 
 ### Changes
-
+- [Database] You can now update the random id schema by importing `import { setGenerator } from '@nozbe/watermelondb/utils/common/randomId'` and then calling `setGenerator(newGenenerator)`. This allows WatermelonDB to create specific IDs for example if your backend uses UUIDs.
 - [Database] You can now pass falsy values to `Database.batch(...)` (false, null, undefined). This is
     useful in keeping code clean when doing operations conditionally. (Also works with `model.batch(...)`)
 - [Decorators]. You can now use `@action` on methods of any object that has a `database: Database`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Changes
+- [Database] You can now update the random id schema by importing `import { setGenerator } from '@nozbe/watermelondb/utils/common/randomId'` and then calling `setGenerator(newGenenerator)`. This allows WatermelonDB to create specific IDs for example if your backend uses UUIDs.
 
 ## 0.12.2 - 2019-04-19
 
@@ -13,7 +14,6 @@ All notable changes to this project will be documented in this file.
 - [TypeScript] 'Cannot use 'in' operator to search for 'initializer'; decorator fix
 
 ### Changes
-- [Database] You can now update the random id schema by importing `import { setGenerator } from '@nozbe/watermelondb/utils/common/randomId'` and then calling `setGenerator(newGenenerator)`. This allows WatermelonDB to create specific IDs for example if your backend uses UUIDs.
 - [Database] You can now pass falsy values to `Database.batch(...)` (false, null, undefined). This is
     useful in keeping code clean when doing operations conditionally. (Also works with `model.batch(...)`)
 - [Decorators]. You can now use `@action` on methods of any object that has a `database: Database`

--- a/src/utils/common/randomId/index.js
+++ b/src/utils/common/randomId/index.js
@@ -13,6 +13,17 @@ const randomCharacter = () => {
 
 // Note: for explanation of generating record IDs on the client side, see:
 // https://github.com/Nozbe/WatermelonDB/issues/5#issuecomment-442046292
-export default function randomId(): string {
+const randomId = (): string => {
   return join('', times(randomCharacter, idLength))
 }
+
+let generator = () => randomId()
+
+export const setGenerator = (newGenerator: void => string) => {
+  if (typeof newGenerator() !== 'string') {
+    throw new Error('RandomId generator function needs to return a string type.')
+  }
+  generator = newGenerator
+}
+
+export default () => generator()

--- a/src/utils/common/randomId/test.js
+++ b/src/utils/common/randomId/test.js
@@ -1,4 +1,4 @@
-import randomId from './index'
+import randomId, { setGenerator } from './index'
 
 describe('randomId', () => {
   it('generates a random string', () => {
@@ -7,5 +7,22 @@ describe('randomId', () => {
 
     const id2 = randomId()
     expect(id2).not.toBe(id1)
+  })
+
+  it('allows to override the generator function', () => {
+    const generator = () => {
+      return new Date()
+        .getTime()
+        .toString()
+        .substr(1, 4)
+    }
+
+    setGenerator(generator)
+
+    expect(randomId().length).toBe(4)
+
+    const invalidGenerator = () => 5
+
+    expect(() => setGenerator(invalidGenerator)).toThrow()
   })
 })


### PR DESCRIPTION
Minor refactor of `randomId` that allows users to provide a custom id generator function to WatermelonDB in order to create specific random id formats (e.g. if UUIDs are used in the backend)

Relates to #7 