### PR TITLE
Private fields

### DIFF
--- a/src/Collection/index.js
+++ b/src/Collection/index.js
@@ -32,7 +32,7 @@ export default class Collection<Record: Model> {
   #cache: RecordCache<Record>
 
   get _cache(): RecordCache<Record> {
-    invariant(process.env.NODE_ENV === 'test', '_chace can be accessed only in test environment')
+    invariant(process.env.NODE_ENV === 'test', '_cache can be accessed only in test environment')
 
     return this.#cache
   }

--- a/src/Collection/index.js
+++ b/src/Collection/index.js
@@ -25,16 +25,22 @@ export default class Collection<Record: Model> {
 
   modelClass: Class<Record>
 
-  _cache: RecordCache<Record>
-
   // Emits event every time a record inside Collection changes or is deleted
   // (Use Query API to observe collection changes)
   changes: Subject<CollectionChangeSet<Record>> = new Subject()
 
+  #cache: RecordCache<Record>
+
+  get _cache(): RecordCache<Record> {
+    invariant(process.env.NODE_ENV === 'test', '_chace can be accessed only in test environment')
+
+    return this.#cache
+  }
+
   constructor(database: Database, ModelClass: Class<Record>): void {
     this.database = database
     this.modelClass = ModelClass
-    this._cache = new RecordCache(ModelClass.table, raw => new ModelClass(this, raw))
+    this.#cache = new RecordCache(ModelClass.table, raw => new ModelClass(this, raw))
   }
 
   // Finds a record with the given ID
@@ -42,7 +48,7 @@ export default class Collection<Record: Model> {
   async find(id: RecordId): Promise<Record> {
     invariant(id, `Invalid record ID ${this.table}#${id}`)
 
-    const cachedRecord = this._cache.get(id)
+    const cachedRecord = this.#cache.get(id)
     return cachedRecord || this._fetchRecord(id)
   }
 
@@ -86,7 +92,7 @@ export default class Collection<Record: Model> {
   async fetchQuery(query: Query<Record>): Promise<Record[]> {
     const rawRecords = await this.database.adapter.query(query)
 
-    return this._cache.recordsFromQueryResult(rawRecords)
+    return this.#cache.recordsFromQueryResult(rawRecords)
   }
 
   // See: Query.fetchCount
@@ -108,7 +114,7 @@ export default class Collection<Record: Model> {
   async _fetchRecord(id: RecordId): Promise<Record> {
     const raw = await this.database.adapter.find(this.table, id)
     invariant(raw, `Record ${this.table}#${id} not found`)
-    return this._cache.recordFromQueryResult(raw)
+    return this.#cache.recordFromQueryResult(raw)
   }
 
   async _markAsDeleted(record: Record): Promise<void> {
@@ -125,7 +131,7 @@ export default class Collection<Record: Model> {
     operations.forEach(({ record, type }) => {
       if (type === CollectionChangeTypes.created) {
         record._isCommitted = true
-        this._cache.add(record)
+        this.#cache.add(record)
       }
     })
 
@@ -139,13 +145,13 @@ export default class Collection<Record: Model> {
   }
 
   _onRecordDestroyed(record: Record): void {
-    this._cache.delete(record)
+    this.#cache.delete(record)
     this.changes.next([{ record, type: CollectionChangeTypes.destroyed }])
     record._notifyDestroyed()
   }
 
   // See: Database.unsafeClearCaches
   unsafeClearCache(): void {
-    this._cache.unsafeClear()
+    this.#cache.unsafeClear()
   }
 }

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -32,13 +32,13 @@ export default class Database {
 
   _actionQueue = new ActionQueue()
 
-  _actionsEnabled: boolean
+  #actionsEnabled: boolean
 
   constructor({ adapter, modelClasses, actionsEnabled = false }: DatabaseProps): void {
     this.adapter = adapter
     this.schema = adapter.schema
     this.collections = new CollectionMap(this, modelClasses)
-    this._actionsEnabled = actionsEnabled
+    this.#actionsEnabled = actionsEnabled
   }
 
   // Executes multiple prepared operations
@@ -135,6 +135,13 @@ export default class Database {
   }
 
   _ensureInAction(error: string): void {
-    this._actionsEnabled && invariant(this._actionQueue.isRunning, error)
+    this.#actionsEnabled && invariant(this._actionQueue.isRunning, error)
+  }
+
+  _ensureActionsEnabled(): void {
+    invariant(
+      this.#actionsEnabled,
+      '[Sync] To use Sync, Actions must be enabled. Pass `{ actionsEnabled: true }` to Database constructor — see docs for more details',
+    )
   }
 }

--- a/src/Query/index.js
+++ b/src/Query/index.js
@@ -3,6 +3,7 @@
 import { type Observable } from 'rxjs/Observable'
 import { prepend } from 'rambdax'
 
+import invariant from '../utils/common/invariant'
 import cacheWhileConnected from '../utils/rx/cacheWhileConnected'
 import allPromises from '../utils/fp/allPromises'
 
@@ -32,7 +33,7 @@ export default class Query<Record: Model> {
 
   description: QueryDescription
 
-  _rawDescription: QueryDescription
+  #rawDescription: QueryDescription
 
   @lazy
   _cachedObservable: Observable<Record[]> = observeQuery(this).pipe(cacheWhileConnected)
@@ -45,19 +46,26 @@ export default class Query<Record: Model> {
     cacheWhileConnected,
   )
 
+  get _rawDescription(): QueryDescription {
+    invariant(
+      process.env.NODE_ENV === 'test',
+      '_rawDescription can be accessed only in test environment',
+    )
+
+    return this.#rawDescription
+  }
+
   // Note: Don't use this directly, use Collection.query(...)
   constructor(collection: Collection<Record>, conditions: Condition[]): void {
     this.collection = collection
-    this._rawDescription = buildQueryDescription(conditions)
-    this.description = queryWithoutDeleted(this._rawDescription)
+    this.#rawDescription = buildQueryDescription(conditions)
+    this.description = queryWithoutDeleted(this.#rawDescription)
   }
 
   // Creates a new Query that extends the conditions of this query
   extend(...conditions: Condition[]): Query<Record> {
-    const {
-      collection,
-      _rawDescription: { join, where },
-    } = this
+    const { collection } = this
+    const { join, where } = this.#rawDescription
 
     return new Query(collection, [...join, ...where, ...conditions])
   }

--- a/src/Relation/index.js
+++ b/src/Relation/index.js
@@ -21,13 +21,29 @@ export type Options = $Exact<{
 // Defines a one-to-one relation between two Models (two tables in db)
 // Do not create this object directly! Use `relation` or `immutableRelation` decorators instead
 export default class Relation<T: ?Model> {
-  _model: Model
+  #model: Model
 
-  _columnName: ColumnName
+  #columnName: ColumnName
 
-  _relationTableName: TableName<$NonMaybeType<T>>
+  #relationTableName: TableName<$NonMaybeType<T>>
 
-  _isImmutable: boolean
+  #isImmutable: boolean
+
+  get _model(): Model {
+    return this.#model
+  }
+
+  get _columnName(): ColumnName {
+    return this.#columnName
+  }
+
+  get _relationTableName(): TableName<$NonMaybeType<T>> {
+    return this.#relationTableName
+  }
+
+  get _isImmutable(): boolean {
+    return this.#isImmutable
+  }
 
   @lazy
   _cachedObservable: Observable<T> = createObservable(this)
@@ -40,33 +56,33 @@ export default class Relation<T: ?Model> {
     columnName: ColumnName,
     options: Options,
   ): void {
-    this._model = model
-    this._relationTableName = relationTableName
-    this._columnName = columnName
-    this._isImmutable = options.isImmutable
+    this.#model = model
+    this.#relationTableName = relationTableName
+    this.#columnName = columnName
+    this.#isImmutable = options.isImmutable
   }
 
   get id(): $Call<ExtractRecordId, T> {
-    return (this._model._getRaw(this._columnName): any)
+    return (this.#model._getRaw(this.#columnName): any)
   }
 
   set id(newId: $Call<ExtractRecordId, T>): void {
-    if (this._isImmutable) {
+    if (this.#isImmutable) {
       invariant(
-        !this._model._isCommitted,
+        !this.#model._isCommitted,
         `Cannot change property marked as @immutableRelation ${
-          Object.getPrototypeOf(this._model).constructor.name
-        } - ${this._columnName}`,
+          Object.getPrototypeOf(this.#model).constructor.name
+        } - ${this.#columnName}`,
       )
     }
 
-    this._model._setRaw(this._columnName, newId || null)
+    this.#model._setRaw(this.#columnName, newId || null)
   }
 
   fetch(): Promise<T> {
     const { id } = this
     if (id) {
-      return this._model.collections.get(this._relationTableName).find(id)
+      return this.#model.collections.get(this.#relationTableName).find(id)
     }
 
     return Promise.resolve((null: any))

--- a/src/sync/impl/helpers.js
+++ b/src/sync/impl/helpers.js
@@ -89,10 +89,7 @@ export function prepareMarkAsSynced<T: Model>(record: T): T {
 }
 
 export function ensureActionsEnabled(database: Database): void {
-  invariant(
-    database._actionsEnabled,
-    '[Sync] To use Sync, Actions must be enabled. Pass `{ actionsEnabled: true }` to Database constructor — see docs for more details',
-  )
+  database._ensureActionsEnabled()
 }
 
 export function ensureSameDatabase(database: Database, initialResetCount: number): void {


### PR DESCRIPTION
Partially adds private fields, just to see if they make sense for us.

- No support for decorated private fields - private fields can't be even accessed from decorated fields, such as @lazy.
- Sometimes there is weird problem with eslint, but I wasn't able to figure it out, and had to skip declaring fields as private.
- Some fields are used by helper functions or other internal parts of 🍉 (eg. tests), so I've made extra getters for these, but I'm not sure if this makes more sense, than keeping them as they are.