### PR TITLE
[rambdax] Use includes instead of contains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - [Schema] Handle invalid table schema argument in appSchema
 - [withObservables] Added TypeScript support ([changelog](https://github.com/Nozbe/withObservables/blob/master/CHANGELOG.md))
 - [Electron] avoid `Uncaught ReferenceError: global is not defined` in electron runtime ([#453](https://github.com/Nozbe/WatermelonDB/issues/453))
+- [rambdax] Replaces `contains` with `includes` due to `contains` deprecation https://github.com/selfrefactor/rambda/commit/1dc1368f81e9f398664c9d95c2efbc48b5cdff9b#diff-04c6e90faac2675aa89e2176d2eec7d8R2209
 
 ## 0.14.0 - 2019-08-02
 

--- a/src/Schema/index.js
+++ b/src/Schema/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { contains } from 'rambdax'
+import { includes } from 'rambdax'
 
 import logger from '../utils/common/logger'
 import isDevelopment from '../utils/common/isDevelopment'
@@ -46,10 +46,8 @@ export function appSchema({
 }: $Exact<{ version: number, tables: TableSchema[] }>): AppSchema {
   isDevelopment && invariant(version > 0, `Schema version must be greater than 0`)
   const tables: TableMap = tableList.reduce((map, table) => {
-    isDevelopment && invariant(
-      typeof table === 'object' && table.name,
-      `Table schema must contain a name`
-    )
+    isDevelopment &&
+      invariant(typeof table === 'object' && table.name, `Table schema must contain a name`)
 
     map[table.name] = table
     return map
@@ -62,11 +60,11 @@ export function validateColumnSchema(column: ColumnSchema): void {
   if (isDevelopment) {
     invariant(column.name, `Missing column name`)
     invariant(
-      contains(column.type, ['string', 'boolean', 'number']),
+      includes(column.type, ['string', 'boolean', 'number']),
       `Invalid type ${column.type} for column ${column.name} (valid: string, boolean, number)`,
     )
     invariant(
-      !contains(column.name, ['id', '_changed', '_status']),
+      !includes(column.name, ['id', '_changed', '_status']),
       `You must not define a column with name ${column.name}`,
     )
     if (column.name === 'created_at' || column.name === 'updated_at') {

--- a/src/observation/encodeMatcher/operators.js
+++ b/src/observation/encodeMatcher/operators.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-disable eqeqeq */
 
-import { contains } from 'rambdax'
+import { includes } from 'rambdax'
 import { gt, gte, lt, lte, complement } from '../../utils/fp'
 import likeToRegexp from '../../utils/fp/likeToRegexp'
 
@@ -51,8 +51,8 @@ const operators: { [Operator]: OperatorFunction } = {
   weakGt,
   lt: noNullComparisons(lt),
   lte: noNullComparisons(lte),
-  oneOf: contains,
-  notIn: noNullComparisons(complement(contains)),
+  oneOf: includes,
+  notIn: noNullComparisons(complement(includes)),
   between,
   like,
   notLike,

--- a/src/sync/impl/applyRemote.js
+++ b/src/sync/impl/applyRemote.js
@@ -4,7 +4,7 @@ import {
   // $FlowFixMe
   promiseAllObject,
   map,
-  contains,
+  includes,
   values,
   filter,
   find,
@@ -51,8 +51,8 @@ async function recordsToApplyRemoteChangesTo<T: Model>(
     ...changes,
     records,
     locallyDeletedIds,
-    recordsToDestroy: filter(record => contains(record.id, deletedIds), records),
-    deletedRecordsToDestroy: filter(id => contains(id, deletedIds), locallyDeletedIds),
+    recordsToDestroy: filter(record => includes(record.id, deletedIds), records),
+    deletedRecordsToDestroy: filter(id => includes(id, deletedIds), locallyDeletedIds),
   }
 }
 
@@ -93,7 +93,7 @@ function prepareApplyRemoteChangesToCollection<T: Model>(
         }, but it already exists locally. This may suggest last sync partially executed, and then failed; or it could be a serious bug. Will update existing record instead.`,
       )
       return prepareUpdateFromRaw(currentRecord, raw, log)
-    } else if (contains(raw.id, locallyDeletedIds)) {
+    } else if (includes(raw.id, locallyDeletedIds)) {
       logError(
         `[Sync] Server wants client to create record ${table}#${
           raw.id
@@ -113,7 +113,7 @@ function prepareApplyRemoteChangesToCollection<T: Model>(
 
     if (currentRecord) {
       return prepareUpdateFromRaw(currentRecord, raw, log)
-    } else if (contains(raw.id, locallyDeletedIds)) {
+    } else if (includes(raw.id, locallyDeletedIds)) {
       // Nothing to do, record was locally deleted, deletion will be pushed later
       return null
     }


### PR DESCRIPTION
- Replaces `contains` with `includes` due to `contains` deprecation https://github.com/selfrefactor/rambda/commit/1dc1368f81e9f398664c9d95c2efbc48b5cdff9b#diff-04c6e90faac2675aa89e2176d2eec7d8R2209
- Resolves #471