### PR TITLE
Added 3 missing TS properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- [Typescript] Added 3 missing properties `collections`, `database` and `asModel` in Model type definition.  
+
 
 ## 0.14.1 - 2019-08-31
 

--- a/src/Model/index.d.ts
+++ b/src/Model/index.d.ts
@@ -54,5 +54,11 @@ declare module '@nozbe/watermelondb/Model' {
     public subAction<T>(action: () => Promise<T>): Promise<T>
 
     public collection: Collection<this>
+                                 
+    public collections: CollectionMap;
+
+    public database: Database;
+
+    public asModel: this;                             
   }
 }

--- a/src/Model/index.d.ts
+++ b/src/Model/index.d.ts
@@ -1,5 +1,5 @@
 declare module '@nozbe/watermelondb/Model' {
-  import { ColumnName, TableName, Collection, RawRecord } from '@nozbe/watermelondb'
+  import { Collection, CollectionMap, ColumnName, Database, RawRecord, TableName } from '@nozbe/watermelondb';
   import { Observable } from 'rxjs'
 
   export type RecordId = string


### PR DESCRIPTION
Since [#377](https://github.com/Nozbe/WatermelonDB/issues/377) hasn't been resolved yet, here is a PR for 3 missing properties in the TS-definitions.

Added properties: 
+ collections
+ database
+ asModel