### PR TITLE
September maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,18 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-- [Typescript] 
+
+### ⚠️ Breaking
+
+- Deprecated `bool` schema column type is removed -- please change to `boolean`
+- `experimentalSetOnlyMarkAsChangedIfDiffers(false)` API is now removed
+
+### Improvements
+
+- [Typescript] Typing improvements
      - Added 3 missing properties `collections`, `database` and `asModel` in Model type definition.
-     - Removed optional flag on `actionsEnabled` in the Database constructor options since its mandatory since 0.13.0. 
-     - fixed several further typing issues in Model, Relation and lazy decorator     
+     - Removed optional flag on `actionsEnabled` in the Database constructor options since its mandatory since 0.13.0.
+     - fixed several further typing issues in Model, Relation and lazy decorator
 
 
 ## 0.14.1 - 2019-08-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to this project will be documented in this file.
      - Added 3 missing properties `collections`, `database` and `asModel` in Model type definition.
      - Removed optional flag on `actionsEnabled` in the Database constructor options since its mandatory since 0.13.0.
      - fixed several further typing issues in Model, Relation and lazy decorator
-
+- Changed how async functions are transpiled in the library. This could break on really old Android phones
+  but shouldn't matter if you use latest version of React Native. Please report an issue if you see a problem.
 
 ## 0.14.1 - 2019-08-31
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -29,14 +29,14 @@ const plugins = [
   '@babel/plugin-transform-sticky-regex',
   '@babel/plugin-transform-unicode-regex',
   // TODO: fast-async is faster and cleaner, but causes a weird issue on older Android RN targets without jsc-android
-  '@babel/plugin-transform-async-to-generator',
-  // [
-  //   // TODO: We can get this faster by tweaking with options, but have to test thoroughly...
-  //   'module:fast-async',
-  //   {
-  //     spec: true,
-  //   },
-  // ],
+  // '@babel/plugin-transform-async-to-generator',
+  [
+    // TODO: We can get this faster by tweaking with options, but have to test thoroughly...
+    'module:fast-async',
+    {
+      spec: true,
+    },
+  ],
 ]
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "prettier-eslint-cli": "^4.7.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
-    "react-hooks-testing-library": "^0.6.0",
+    "@testing-library/react-hooks": "^1.1.0",
     "react-native": "^0.59.3",
     "react-test-renderer": "16.9.0",
     "rimraf": "^3.0.0",

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -34,13 +34,20 @@ export default class Database {
   #actionsEnabled: boolean
 
   constructor({ adapter, modelClasses, actionsEnabled }: DatabaseProps): void {
+    if (process.env.NODE_ENV !== 'production') {
+      invariant(adapter, `Missing adapter parameter for new Database()`)
+      invariant(
+        modelClasses && Array.isArray(modelClasses),
+        `Missing modelClasses parameter for new Database()`,
+      )
+      invariant(
+        actionsEnabled === true || actionsEnabled === false,
+        'You must pass `actionsEnabled:` key to Database constructor. It is highly recommended you pass `actionsEnabled: true` (see documentation for more details), but can pass `actionsEnabled: false` for backwards compatibility.',
+      )
+    }
     this.adapter = adapter
     this.schema = adapter.schema
     this.collections = new CollectionMap(this, modelClasses)
-    invariant(
-      actionsEnabled === true || actionsEnabled === false,
-      'You must pass `actionsEnabled:` key to Database constructor. It is highly recommended you pass `actionsEnabled: true` (see documentation for more details), but can pass `actionsEnabled: false` for backwards compatibility.',
-    )
     this.#actionsEnabled = actionsEnabled
   }
 

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -31,7 +31,7 @@ export default class Database {
 
   _actionQueue = new ActionQueue()
 
-  #actionsEnabled: boolean
+  _actionsEnabled: boolean
 
   constructor({ adapter, modelClasses, actionsEnabled }: DatabaseProps): void {
     if (process.env.NODE_ENV !== 'production') {
@@ -48,7 +48,7 @@ export default class Database {
     this.adapter = adapter
     this.schema = adapter.schema
     this.collections = new CollectionMap(this, modelClasses)
-    this.#actionsEnabled = actionsEnabled
+    this._actionsEnabled = actionsEnabled
   }
 
   // Executes multiple prepared operations
@@ -150,13 +150,6 @@ export default class Database {
   }
 
   _ensureInAction(error: string): void {
-    this.#actionsEnabled && invariant(this._actionQueue.isRunning, error)
-  }
-
-  _ensureActionsEnabled(): void {
-    invariant(
-      this.#actionsEnabled,
-      '[Sync] To use Sync, Actions must be enabled. Pass `{ actionsEnabled: true }` to Database constructor — see docs for more details',
-    )
+    this._actionsEnabled && invariant(this._actionQueue.isRunning, error)
   }
 }

--- a/src/Model/index.js
+++ b/src/Model/index.js
@@ -2,7 +2,6 @@
 
 import type { Observable } from 'rxjs'
 import { BehaviorSubject } from 'rxjs/BehaviorSubject'
-import isDevelopment from '../utils/common/isDevelopment'
 import invariant from '../utils/common/invariant'
 import ensureSync from '../utils/common/ensureSync'
 import fromPairs from '../utils/fp/fromPairs'
@@ -113,7 +112,7 @@ export default class Model {
     // TODO: `process.nextTick` doesn't work on React Native
     // We could polyfill with setImmediate, but it doesn't have the same effect — test and enseure
     // it would actually work for this purpose
-    if (isDevelopment && process && process.nextTick) {
+    if (process.env.NODE_ENV !== 'production' && process && process.nextTick) {
       process.nextTick(() => {
         invariant(
           !this._hasPendingUpdate,

--- a/src/Model/index.js
+++ b/src/Model/index.js
@@ -8,9 +8,6 @@ import fromPairs from '../utils/fp/fromPairs'
 import noop from '../utils/fp/noop'
 import type { $RE } from '../types'
 
-import field from '../decorators/field'
-import readonly from '../decorators/readonly'
-
 import type Database from '../Database'
 import type Collection from '../Collection'
 import type CollectionMap from '../Database/CollectionMap'
@@ -59,13 +56,13 @@ export default class Model {
 
   _changes = new BehaviorSubject(this)
 
-  @readonly
-  @field('id')
-  id: RecordId
+  get id(): RecordId {
+    return this._raw.id
+  }
 
-  @readonly
-  @field('_status')
-  syncStatus: SyncStatus
+  get syncStatus(): SyncStatus {
+    return this._raw._status
+  }
 
   // Modifies the model (using passed function) and saves it to the database.
   // Touches `updatedAt` if available.

--- a/src/Model/index.js
+++ b/src/Model/index.js
@@ -36,12 +36,6 @@ export function associations(
   return (fromPairs(associationList): any)
 }
 
-let experimentalOnlyMarkAsChangedIfDiffers = true
-
-export function experimentalSetOnlyMarkAsChangedIfDiffers(value: boolean): void {
-  experimentalOnlyMarkAsChangedIfDiffers = value
-}
-
 export default class Model {
   // Set this in concrete Models to the name of the database table
   static +table: TableName<this>
@@ -274,10 +268,7 @@ export default class Model {
     const valueBefore = this._raw[(rawFieldName: string)]
     setRawSanitized(this._raw, rawFieldName, rawValue, this.collection.schema.columns[rawFieldName])
 
-    if (
-      !experimentalOnlyMarkAsChangedIfDiffers ||
-      valueBefore !== this._raw[(rawFieldName: string)]
-    ) {
+    if (valueBefore !== this._raw[(rawFieldName: string)]) {
       setRawColumnChange(this._raw, rawFieldName)
     }
   }

--- a/src/Model/test.js
+++ b/src/Model/test.js
@@ -10,7 +10,7 @@ import { field, date, readonly } from '../decorators'
 import { noop, allPromises } from '../utils/fp'
 import { sanitizedRaw } from '../RawRecord'
 
-import Model, { experimentalSetOnlyMarkAsChangedIfDiffers } from './index'
+import Model from './index'
 import { fetchChildren } from './helpers'
 
 const mockSchema = appSchema({
@@ -532,8 +532,6 @@ describe('Sync status fields', () => {
       ),
     )
 
-    experimentalSetOnlyMarkAsChangedIfDiffers(true)
-
     model._isEditing = true
     model._raw.id = 'xxx'
     model._raw._status = 'updated'
@@ -556,8 +554,6 @@ describe('Sync status fields', () => {
       col4: null,
       number: 10,
     })
-
-    experimentalSetOnlyMarkAsChangedIfDiffers(false)
   })
   it('marks new records as status:created', async () => {
     const database = makeDatabase()
@@ -671,7 +667,9 @@ describe('model helpers', () => {
     })
 
     const commentPromise = async task => {
-      const comment = await comments.create(mock => { mock.task.set(task) })
+      const comment = await comments.create(mock => {
+        mock.task.set(task)
+      })
       const commentChildren = await fetchChildren(comment)
       expect(commentChildren).toHaveLength(0)
     }

--- a/src/Query/index.js
+++ b/src/Query/index.js
@@ -3,7 +3,6 @@
 import { type Observable } from 'rxjs/Observable'
 import { prepend } from 'rambdax'
 
-import invariant from '../utils/common/invariant'
 import cacheWhileConnected from '../utils/rx/cacheWhileConnected'
 import allPromises from '../utils/fp/allPromises'
 
@@ -33,7 +32,7 @@ export default class Query<Record: Model> {
 
   description: QueryDescription
 
-  #rawDescription: QueryDescription
+  _rawDescription: QueryDescription
 
   @lazy
   _cachedObservable: Observable<Record[]> = observeQuery(this).pipe(cacheWhileConnected)
@@ -46,26 +45,17 @@ export default class Query<Record: Model> {
     cacheWhileConnected,
   )
 
-  get _rawDescription(): QueryDescription {
-    invariant(
-      process.env.NODE_ENV === 'test',
-      '_rawDescription can be accessed only in test environment',
-    )
-
-    return this.#rawDescription
-  }
-
   // Note: Don't use this directly, use Collection.query(...)
   constructor(collection: Collection<Record>, conditions: Condition[]): void {
     this.collection = collection
-    this.#rawDescription = buildQueryDescription(conditions)
-    this.description = queryWithoutDeleted(this.#rawDescription)
+    this._rawDescription = buildQueryDescription(conditions)
+    this.description = queryWithoutDeleted(this._rawDescription)
   }
 
   // Creates a new Query that extends the conditions of this query
   extend(...conditions: Condition[]): Query<Record> {
     const { collection } = this
-    const { join, where } = this.#rawDescription
+    const { join, where } = this._rawDescription
 
     return new Query(collection, [...join, ...where, ...conditions])
   }

--- a/src/Relation/index.js
+++ b/src/Relation/index.js
@@ -21,29 +21,13 @@ export type Options = $Exact<{
 // Defines a one-to-one relation between two Models (two tables in db)
 // Do not create this object directly! Use `relation` or `immutableRelation` decorators instead
 export default class Relation<T: ?Model> {
-  #model: Model
+  _model: Model
 
-  #columnName: ColumnName
+  _columnName: ColumnName
 
-  #relationTableName: TableName<$NonMaybeType<T>>
+  _relationTableName: TableName<$NonMaybeType<T>>
 
-  #isImmutable: boolean
-
-  get _model(): Model {
-    return this.#model
-  }
-
-  get _columnName(): ColumnName {
-    return this.#columnName
-  }
-
-  get _relationTableName(): TableName<$NonMaybeType<T>> {
-    return this.#relationTableName
-  }
-
-  get _isImmutable(): boolean {
-    return this.#isImmutable
-  }
+  _isImmutable: boolean
 
   @lazy
   _cachedObservable: Observable<T> = createObservable(this)
@@ -56,33 +40,33 @@ export default class Relation<T: ?Model> {
     columnName: ColumnName,
     options: Options,
   ): void {
-    this.#model = model
-    this.#relationTableName = relationTableName
-    this.#columnName = columnName
-    this.#isImmutable = options.isImmutable
+    this._model = model
+    this._relationTableName = relationTableName
+    this._columnName = columnName
+    this._isImmutable = options.isImmutable
   }
 
   get id(): $Call<ExtractRecordId, T> {
-    return (this.#model._getRaw(this.#columnName): any)
+    return (this._model._getRaw(this._columnName): any)
   }
 
   set id(newId: $Call<ExtractRecordId, T>): void {
-    if (this.#isImmutable) {
+    if (this._isImmutable) {
       invariant(
-        !this.#model._isCommitted,
+        !this._model._isCommitted,
         `Cannot change property marked as @immutableRelation ${
-          Object.getPrototypeOf(this.#model).constructor.name
-        } - ${this.#columnName}`,
+          Object.getPrototypeOf(this._model).constructor.name
+        } - ${this._columnName}`,
       )
     }
 
-    this.#model._setRaw(this.#columnName, newId || null)
+    this._model._setRaw(this._columnName, newId || null)
   }
 
   fetch(): Promise<T> {
     const { id } = this
     if (id) {
-      return this.#model.collections.get(this.#relationTableName).find(id)
+      return this._model.collections.get(this._relationTableName).find(id)
     }
 
     return Promise.resolve((null: any))

--- a/src/Schema/index.js
+++ b/src/Schema/index.js
@@ -2,7 +2,6 @@
 
 import { includes } from 'rambdax'
 
-import logger from '../utils/common/logger'
 import invariant from '../utils/common/invariant'
 import type { $RE } from '../types'
 
@@ -88,18 +87,6 @@ export function tableSchema({ name, columns: columnList }: TableSchemaSpec): Tab
   }
 
   const columns: ColumnMap = columnList.reduce((map, column) => {
-    // TODO: `bool` is deprecated -- remove compat after a while
-    if (column.type === 'bool') {
-      column.type = 'boolean'
-      if (process.env.NODE_ENV !== 'production') {
-        logger.warn(
-          `[DEPRECATION] Column type 'bool' is deprecated — change to 'boolean' (in ${JSON.stringify(
-            column,
-          )})`,
-        )
-      }
-    }
-
     if (process.env.NODE_ENV !== 'production') {
       validateColumnSchema(column)
     }

--- a/src/Schema/index.js
+++ b/src/Schema/index.js
@@ -3,7 +3,6 @@
 import { includes } from 'rambdax'
 
 import logger from '../utils/common/logger'
-import isDevelopment from '../utils/common/isDevelopment'
 import invariant from '../utils/common/invariant'
 import type { $RE } from '../types'
 
@@ -44,9 +43,10 @@ export function appSchema({
   version,
   tables: tableList,
 }: $Exact<{ version: number, tables: TableSchema[] }>): AppSchema {
-  isDevelopment && invariant(version > 0, `Schema version must be greater than 0`)
+  process.env.NODE_ENV !== 'production' &&
+    invariant(version > 0, `Schema version must be greater than 0`)
   const tables: TableMap = tableList.reduce((map, table) => {
-    isDevelopment &&
+    process.env.NODE_ENV !== 'production' &&
       invariant(typeof table === 'object' && table.name, `Table schema must contain a name`)
 
     map[table.name] = table
@@ -57,7 +57,7 @@ export function appSchema({
 }
 
 export function validateColumnSchema(column: ColumnSchema): void {
-  if (isDevelopment) {
+  if (process.env.NODE_ENV !== 'production') {
     invariant(column.name, `Missing column name`)
     invariant(
       includes(column.type, ['string', 'boolean', 'number']),
@@ -83,12 +83,15 @@ export function validateColumnSchema(column: ColumnSchema): void {
 }
 
 export function tableSchema({ name, columns: columnList }: TableSchemaSpec): TableSchema {
-  isDevelopment && invariant(name, `Missing table name in schema`)
+  if (process.env.NODE_ENV !== 'production') {
+    invariant(name, `Missing table name in schema`)
+  }
+
   const columns: ColumnMap = columnList.reduce((map, column) => {
     // TODO: `bool` is deprecated -- remove compat after a while
     if (column.type === 'bool') {
       column.type = 'boolean'
-      if (isDevelopment) {
+      if (process.env.NODE_ENV !== 'production') {
         logger.warn(
           `[DEPRECATION] Column type 'bool' is deprecated — change to 'boolean' (in ${JSON.stringify(
             column,
@@ -97,7 +100,7 @@ export function tableSchema({ name, columns: columnList }: TableSchemaSpec): Tab
       }
     }
 
-    if (isDevelopment) {
+    if (process.env.NODE_ENV !== 'production') {
       validateColumnSchema(column)
     }
     map[column.name] = column

--- a/src/Schema/migrations/index.js
+++ b/src/Schema/migrations/index.js
@@ -4,7 +4,7 @@ import { sortBy, prop, last, head } from 'rambdax'
 import type { ColumnSchema, TableName, ColumnMap, TableSchemaSpec, SchemaVersion } from '../index'
 import { tableSchema, validateColumnSchema } from '../index'
 
-import { isDevelopment, invariant } from '../../utils/common'
+import { invariant } from '../../utils/common'
 import { isObject } from '../../utils/fp'
 
 export type CreateTableMigrationStep = $Exact<{
@@ -80,7 +80,7 @@ const sortMigrations = sortBy(prop('toVersion'))
 export function schemaMigrations(migrationSpec: SchemaMigrationsSpec): SchemaMigrations {
   const { migrations } = migrationSpec
 
-  if (isDevelopment) {
+  if (process.env.NODE_ENV !== 'production') {
     // validate migrations spec object
     invariant(Array.isArray(migrations), 'Missing migrations array')
 
@@ -106,7 +106,7 @@ export function schemaMigrations(migrationSpec: SchemaMigrationsSpec): SchemaMig
   const minVersion = oldestMigration ? oldestMigration.toVersion - 1 : 1
   const maxVersion = newestMigration?.toVersion || 1
 
-  if (isDevelopment) {
+  if (process.env.NODE_ENV !== 'production') {
     // validate that migration spec is without gaps and duplicates
     sortedMigrations.reduce((maxCoveredVersion, migration) => {
       const { toVersion } = migration
@@ -139,7 +139,7 @@ export function addColumns({
   table,
   columns,
 }: $Exact<{ table: TableName<any>, columns: ColumnSchema[] }>): AddColumnsMigrationStep {
-  if (isDevelopment) {
+  if (process.env.NODE_ENV !== 'production') {
     invariant(table, `Missing table name in addColumn()`)
     invariant(columns && Array.isArray(columns), `Missing 'columns' or not an array in addColumn()`)
     columns.forEach(column => validateColumnSchema(column))

--- a/src/Schema/test.js
+++ b/src/Schema/test.js
@@ -13,7 +13,7 @@ describe('Schema', () => {
           name: 'bar',
           columns: [
             { name: 'col1', type: 'number' },
-            { name: 'col2', type: 'bool' }, // TODO: Deprecated (remove after a while)
+            { name: 'col2', type: 'boolean' },
             { name: 'col3', type: 'boolean' },
           ],
         }),

--- a/src/__tests__/databaseTests.js
+++ b/src/__tests__/databaseTests.js
@@ -308,10 +308,7 @@ export const matchTests = [
       { id: 'm1', text1: 'Lorem ipsum dolor sit amet,' },
       { id: 'm2', text1: 'Lorem Ipsum dolor sit amet,' },
     ],
-    nonMatching: [
-      { id: 'n1', text1: 'consectetur adipiscing elit.' },
-      { id: 'n2', text1: null },
-    ],
+    nonMatching: [{ id: 'n1', text1: 'consectetur adipiscing elit.' }, { id: 'n2', text1: null }],
   },
   {
     name: 'match notLike (string)',
@@ -321,16 +318,12 @@ export const matchTests = [
       { id: 'm2', text1: 'Lorem Ipsum dolor sit amet,' },
       { id: 'm3', text1: null },
     ],
-    matching: [
-      { id: 'n1', text1: 'consectetur adipiscing elit.' },
-    ],
+    matching: [{ id: 'n1', text1: 'consectetur adipiscing elit.' }],
   },
   {
     name: 'match like (value%)',
     query: [Q.where('text1', Q.like('Lorem%'))],
-    matching: [
-      { id: 'm1', text1: 'Lorem Ipsum dolor sit amet,' },
-    ],
+    matching: [{ id: 'm1', text1: 'Lorem Ipsum dolor sit amet,' }],
     nonMatching: [
       { id: 'n1', text1: 'consectetur adipiscing elit.' },
       { id: 'n2', text1: 'Vestibulum eget felis commodo, gravida velit nec, congue lorem.' },
@@ -341,10 +334,7 @@ export const matchTests = [
   {
     name: 'match notLike (value%)',
     query: [Q.where('text1', Q.notLike('Lorem%'))],
-    nonMatching: [
-      { id: 'm1', text1: 'Lorem Ipsum dolor sit amet,' },
-      { id: 'm2', text1: null },
-    ],
+    nonMatching: [{ id: 'm1', text1: 'Lorem Ipsum dolor sit amet,' }, { id: 'm2', text1: null }],
     matching: [
       { id: 'n1', text1: 'consectetur adipiscing elit.' },
       { id: 'n2', text1: 'Vestibulum eget felis commodo, gravida velit nec, congue lorem.' },
@@ -382,9 +372,7 @@ export const matchTests = [
   {
     name: 'match like (value%value)',
     query: [Q.where('text1', Q.like('lorem%elit'))],
-    matching: [
-      { id: 'm1', text1: 'Lorem Ipsum dolor sit amet, consectetur adipiscing elit' },
-    ],
+    matching: [{ id: 'm1', text1: 'Lorem Ipsum dolor sit amet, consectetur adipiscing elit' }],
     nonMatching: [
       { id: 'n1', text1: 'Lorem Ipsum dolor sit amet,' },
       { id: 'n2', text1: 'Vestibulum eget felis commodo, gravida velit nec, congue lorem' },
@@ -478,10 +466,7 @@ export const matchTests = [
   {
     name: 'match like (_alu_)',
     query: [Q.where('text1', Q.like('_ore_'))],
-    matching: [
-      { id: 'm1', text1: 'Lorem' },
-      { id: 'm2', text1: 'poret' },
-    ],
+    matching: [{ id: 'm1', text1: 'Lorem' }, { id: 'm2', text1: 'poret' }],
     nonMatching: [
       { id: 'n1', text1: 'Lorem Ipsum dolor sit amet,' },
       { id: 'n2', text1: 'Vestibulum eget felis commodo, gravida velit nec, congue lorem' },
@@ -494,9 +479,7 @@ export const matchTests = [
   {
     name: 'match like sanitized (value%)',
     query: [Q.where('text1', Q.like(Q.sanitizeLikeString('lorem%')))],
-    matching: [
-      { id: 'm2', text1: 'Lorem%' },
-    ],
+    matching: [{ id: 'm2', text1: 'Lorem%' }],
     nonMatching: [
       { id: 'n1', text1: 'Lorem Ipsum dolor sit amet,' },
       { id: 'n2', text1: 'Vestibulum eget felis commodo, gravida velit nec, congue lorem' },
@@ -509,9 +492,7 @@ export const matchTests = [
   {
     name: 'match like sanitized (value_)',
     query: [Q.where('text1', Q.like(Q.sanitizeLikeString('lorem_')))],
-    matching: [
-      { id: 'm2', text1: 'Lorem%' },
-    ],
+    matching: [{ id: 'm2', text1: 'Lorem%' }],
     nonMatching: [
       { id: 'n1', text1: 'Lorem Ipsum dolor sit amet,' },
       { id: 'n2', text1: 'Vestibulum eget felis commodo, gravida velit nec, congue lorem' },
@@ -524,9 +505,7 @@ export const matchTests = [
   {
     name: 'match like sanitized (value.*)',
     query: [Q.where('text1', Q.like(Q.sanitizeLikeString('lorem.*')))],
-    matching: [
-      { id: 'm2', text1: 'Lorem.*' },
-    ],
+    matching: [{ id: 'm2', text1: 'Lorem.*' }],
     nonMatching: [
       { id: 'n1', text1: 'Lorem Ipsum dolor sit amet,' },
       { id: 'n2', text1: 'Vestibulum eget felis commodo, gravida velit nec, congue lorem' },
@@ -660,7 +639,7 @@ export const joinTests = [
     ],
   },
   {
-    name: 'can perform a JOIN query containing JGT column comparison',
+    name: 'can perform a JOIN query containing weakGt column comparison',
     query: [Q.on('projects', 'num1', Q.weakGt(Q.column('num2')))],
     extraRecords: {
       projects: [

--- a/src/adapters/common.js
+++ b/src/adapters/common.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { devMeasureTimeAsync, logger, isDevelopment, invariant } from '../utils/common'
+import { devMeasureTimeAsync, logger, invariant } from '../utils/common'
 import type Model, { RecordId } from '../Model'
 import type Query from '../Query'
 import type { TableSchema } from '../Schema'
@@ -11,7 +11,7 @@ export type DirtyFindResult = RecordId | ?DirtyRaw
 export type DirtyQueryResult = Array<RecordId | DirtyRaw>
 
 export function validateAdapter(adapter: DatabaseAdapter): void {
-  if (isDevelopment) {
+  if (process.env.NODE_ENV !== 'production') {
     const { schema, migrations } = adapter
     // TODO: uncomment when full migrations are shipped
     // invariant(migrations, `Missing migrations`)

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -56,6 +56,7 @@ export default class LokiJSAdapter implements DatabaseAdapter {
     this.schema = schema
     this.migrations = migrations
     this._dbName = dbName
+
     if (process.env.NODE_ENV !== 'production') {
       invariant(
         // $FlowFixMe

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -87,20 +87,20 @@ export default class LokiJSAdapter implements DatabaseAdapter {
     })
   }
 
-  async find(table: TableName<any>, id: RecordId): Promise<CachedFindResult> {
+  find(table: TableName<any>, id: RecordId): Promise<CachedFindResult> {
     return devLogFind(() => this.workerBridge.send(FIND, [table, id]), table, id)
   }
 
-  async query<T: Model>(query: Query<T>): Promise<CachedQueryResult> {
+  query<T: Model>(query: Query<T>): Promise<CachedQueryResult> {
     return devLogQuery(() => this.workerBridge.send(QUERY, [query.serialize()]), query)
   }
 
-  async count<T: Model>(query: Query<T>): Promise<number> {
+  count<T: Model>(query: Query<T>): Promise<number> {
     return devLogCount(() => this.workerBridge.send(COUNT, [query.serialize()]), query)
   }
 
-  async batch(operations: BatchOperation[]): Promise<void> {
-    await devLogBatch(
+  batch(operations: BatchOperation[]): Promise<void> {
+    return devLogBatch(
       () =>
         this.workerBridge.send(BATCH, [
           map(([type, record]) => [type, record.table, record._raw], operations),

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -85,13 +85,16 @@ export default class SQLiteAdapter implements DatabaseAdapter {
     this.schema = schema
     this.migrations = migrations
     this._dbName = this._getName(dbName)
-    isDevelopment && validateAdapter(this)
 
     if (process.env.NODE_ENV !== 'production') {
       invariant(
         // $FlowFixMe
         options.migrationsExperimental === undefined,
         'SQLiteAdapter migrationsExperimental has been renamed to migrations',
+      )
+      invariant(
+        Native,
+        `NativeModules.DatabaseBridge is not defined! This means that you haven't properly linked WatermelonDB native module. Refer to docs for more details`,
       )
       validateAdapter(this)
     }

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -170,7 +170,7 @@ export default class SQLiteAdapter implements DatabaseAdapter {
     logger.log(`[DB] Schema set up successfully`)
   }
 
-  async find(table: TableName<any>, id: RecordId): Promise<CachedFindResult> {
+  find(table: TableName<any>, id: RecordId): Promise<CachedFindResult> {
     return devLogFind(
       async () =>
         sanitizeFindResult(await Native.find(this._tag, table, id), this.schema.tables[table]),
@@ -179,7 +179,7 @@ export default class SQLiteAdapter implements DatabaseAdapter {
     )
   }
 
-  async query<T: Model>(query: Query<T>): Promise<CachedQueryResult> {
+  query<T: Model>(query: Query<T>): Promise<CachedQueryResult> {
     return devLogQuery(
       async () =>
         sanitizeQueryResult(
@@ -190,12 +190,12 @@ export default class SQLiteAdapter implements DatabaseAdapter {
     )
   }
 
-  async count<T: Model>(query: Query<T>): Promise<number> {
+  count<T: Model>(query: Query<T>): Promise<number> {
     return devLogCount(() => Native.count(this._tag, encodeQuery(query, true)), query)
   }
 
-  async batch(operations: BatchOperation[]): Promise<void> {
-    await devLogBatch(async () => {
+  batch(operations: BatchOperation[]): Promise<void> {
+    return devLogBatch(async () => {
       await Native.batch(
         this._tag,
         operations.map(([type, record]) => {

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -2,13 +2,7 @@
 /* eslint-disable global-require */
 
 import { NativeModules } from 'react-native'
-import {
-  connectionTag,
-  type ConnectionTag,
-  logger,
-  isDevelopment,
-  invariant,
-} from '../../utils/common'
+import { connectionTag, type ConnectionTag, logger, invariant } from '../../utils/common'
 
 import type Model, { RecordId } from '../../Model'
 import type Query from '../../Query'

--- a/src/hooks/test.js
+++ b/src/hooks/test.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import * as TestRenderer from 'react-test-renderer'
-import { renderHook } from 'react-hooks-testing-library'
+import { renderHook } from '@testing-library/react-hooks'
 import { useDatabase } from './use-database'
 import DatabaseProvider from '../DatabaseProvider'
 import Database from '../Database'
 import { MockProject, MockTask, MockComment } from '../__tests__/testModels'
 
 /**
- * Note: this uses two testing libraries; react-test-renderer and react-hooks-testing-library.
+ * Note: this uses two testing libraries; react-test-renderer and @testing-library/react-hooks.
  * This is probably overkill for such a simple hook but I will leave these here in case more
  * hooks are added in the future.
  * */

--- a/src/sync/impl/helpers.js
+++ b/src/sync/impl/helpers.js
@@ -91,7 +91,10 @@ export function prepareMarkAsSynced<T: Model>(record: T): T {
 }
 
 export function ensureActionsEnabled(database: Database): void {
-  database._ensureActionsEnabled()
+  invariant(
+    database._actionsEnabled,
+    '[Sync] To use Sync, Actions must be enabled. Pass `{ actionsEnabled: true }` to Database constructor — see docs for more details',
+  )
 }
 
 export function ensureSameDatabase(database: Database, initialResetCount: number): void {

--- a/src/utils/common/index.js
+++ b/src/utils/common/index.js
@@ -4,7 +4,6 @@ export { getPreciseTime, devMeasureTime, devMeasureTimeAsync } from './devMeasur
 export { default as randomId } from './randomId'
 export { default as makeDecorator } from './makeDecorator'
 export { default as ensureSync } from './ensureSync'
-export { default as isDevelopment } from './isDevelopment'
 export { default as invariant } from './invariant'
 export { default as logError } from './logError'
 export { default as logger } from './logger'

--- a/src/utils/common/isDevelopment/index.js
+++ b/src/utils/common/isDevelopment/index.js
@@ -1,7 +1,0 @@
-// @flow
-
-// It's faster to cache NODE_ENV
-// See: https://github.com/facebook/react/issues/812
-const isDevelopment = process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'
-
-export default isDevelopment

--- a/yarn.lock
+++ b/yarn.lock
@@ -1220,12 +1220,14 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@testing-library/react-hooks@~1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-1.0.2.tgz#85a91e6c63015cc861f42713f9066bf62f491457"
-  integrity sha512-YBSeOC3diWm1DQUjj1Nixj8Y1O3GA6gZaQo3QrmRxslUF8utN0ywZOY7rWbbFdgoSJUdWb6LWU8LwIN+/egujg==
+"@testing-library/react-hooks@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-1.1.0.tgz#14b6b5c7c3d0e2cb3e55e9cbb248b44321641c64"
+  integrity sha512-piE/ceQoNf134FFVXBABDbttBJ8eLPD4eg7zIciVJv92RyvoIsBHCvvG8Vd4IG5pyuWYrkLsZTO8ucZBwa4twA==
   dependencies:
     "@babel/runtime" "^7.4.2"
+    "@types/react" "^16.8.22"
+    "@types/react-test-renderer" "^16.8.2"
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -1241,6 +1243,21 @@
   version "15.7.0"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.0.tgz#4c48fed958d6dcf9487195a0ef6456d5f6e0163a"
   integrity sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==
+
+"@types/react-test-renderer@^16.8.2":
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.0.tgz#d60f530ecf4c906721511603cca711b4fa830d41"
+  integrity sha512-bN5EyjtuTY35xX7N5j0KP1vg5MpUXHpFTX6tGsqkNOthjNvet4VQOYRxFh+NT5cDSJrATmAFK9NLeYZ4mp/o0Q==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^16.8.22":
+  version "16.9.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.3.tgz#6d13251e441a3e67fb60d719d1fc8785b984a2ec"
+  integrity sha512-Ogb2nSn+2qQv5opoCv7Ls5yFxtyrdUYxp5G+SWTrlGk7dmFKw331GiezCgEZj9U7QeXJi1CDtws9pdXU1zUL4g==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/react@^16.8.6":
   version "16.8.6"
@@ -6756,13 +6773,6 @@ react-dom@^16.9.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.15.0"
-
-react-hooks-testing-library@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/react-hooks-testing-library/-/react-hooks-testing-library-0.6.0.tgz#2e96dbd32c405d8f1b3949e1fc22f6924305e28b"
-  integrity sha512-VzOF4ZYMWR2B0RQgRXmxolmSMy7uvUPgmVm/CqSeyTRiITMQXiTywK65sjoIHzsQ6tW1R8hbljSYU02PgGdvCA==
-  dependencies:
-    "@testing-library/react-hooks" "~1.0.2"
 
 react-is@^16.8.1, react-is@^16.9.0:
   version "16.9.0"


### PR DESCRIPTION
- Eliminated some deprecated APIs
- Fix a dependency
- Remove the use of esnext private properties… they cause more problems than they solve (they don't really solve any problems, it's just neat syntax) — we have to define getters anyway, the code they spit out is suboptimal, eslint/other tools sometimes crash on this for no reason
- add some helpful error messages
- some random micro optimizations - remove unneeded `async`, turn back on `fast-async` babel transform, remove unnecessary use of decorators, remove isDevelopment helper (use process.env... check inline so that babel can dead code eliminate it for production builds --- when we set that up in the future ;P )