### PR TITLE
upate web demo to use withDatabase hoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### New 
+ - Avoid `database` prop drilling in the web demo
+
 ### ⚠️ Breaking
 
 - Deprecated `bool` schema column type is removed -- please change to `boolean`

--- a/examples/web/src/components/Blog/index.js
+++ b/examples/web/src/components/Blog/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { compose, withPropsOnChange, withHandlers, withStateHandlers } from 'recompose'
 import withObservables from '@nozbe/with-observables'
+import { withDatabase } from '@nozbe/watermelondb/DatabaseProvider'
 
 import Button from 'components/Button'
 import ListItem from 'components/ListItem'
@@ -99,4 +100,4 @@ const enhance = compose(
   }),
 )
 
-export default enhance(Blog)
+export default withDatabase(enhance(Blog))

--- a/examples/web/src/components/BlogList/index.js
+++ b/examples/web/src/components/BlogList/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { compose, withStateHandlers, withHandlers } from 'recompose'
 import { Q } from '@nozbe/watermelondb'
 import withObservables from '@nozbe/with-observables'
+import { withDatabase } from '@nozbe/watermelondb/DatabaseProvider'
 
 import ListItem from 'components/ListItem'
 
@@ -61,4 +62,4 @@ const enhance = compose(
   ),
 )
 
-export default enhance(BlogList)
+export default withDatabase(enhance(BlogList))

--- a/examples/web/src/components/ModerationQueue/index.js
+++ b/examples/web/src/components/ModerationQueue/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { compose, withPropsOnChange } from 'recompose'
 import withObservables from '@nozbe/with-observables'
+import { withDatabase } from '@nozbe/watermelondb/DatabaseProvider'
 
 import Comment from 'components/Comment'
 import BackLink from 'components/BackLink'
@@ -31,4 +32,4 @@ const enhance = compose(
   })),
 )
 
-export default enhance(ModerationQueue)
+export default withDatabase(enhance(ModerationQueue))

--- a/examples/web/src/components/Post/index.js
+++ b/examples/web/src/components/Post/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { compose, withPropsOnChange, withHandlers } from 'recompose'
 
 import withObservables from '@nozbe/with-observables'
+import { withDatabase } from '@nozbe/watermelondb/DatabaseProvider'
 
 import Comment from 'components/Comment'
 import Button from 'components/Button'
@@ -50,4 +51,4 @@ const enhance = compose(
     },
   }),
 )
-export default enhance(Post)
+export default withDatabase(enhance(Post))

--- a/examples/web/src/components/Root/index.js
+++ b/examples/web/src/components/Root/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { HashRouter as Router, Route, Switch, Link } from 'react-router-dom'
 import { generate100, generate10k } from 'models/generate'
+import { withDatabase } from '@nozbe/watermelondb/DatabaseProvider'
 
 import Button from 'components/Button'
 import BlogList from 'components/BlogList'
@@ -52,7 +53,6 @@ class Root extends Component {
   hideMain = () => this.setState({isShowMain: false});
 
   render() {
-    const { database } = this.props
     const { isGenerating, search, isShowPostList, isShowMain } = this.state
 
     return (
@@ -77,7 +77,7 @@ class Root extends Component {
                 type="text"
                 defaultValue=""
                 onChange={this.handleTextChange} />
-              {!isGenerating && <BlogList search={search} database={database} showPostList={this.showPostList} />}
+              {!isGenerating && <BlogList search={search} showPostList={this.showPostList} />}
             </div>
 
               <Route path="/blog/:blogId"
@@ -85,7 +85,7 @@ class Root extends Component {
                   (!isGenerating && (isShowPostList || props.match.params.blogId)) && (
                       <div className={style.postList}>
                         <BackLink to="/blog" onClick={this.hidePostList}>&lt; Back</BackLink>
-                        <Blog key={props.match.params.blogId} database={database} {...props} showMain={this.showMain} />
+                        <Blog key={props.match.params.blogId} {...props} showMain={this.showMain} />
                       </div>
                   )
                 }
@@ -99,14 +99,14 @@ class Root extends Component {
                       <Route path="/blog/:blogId/nasty"
                         render={props => (isShowMain || props.match.params.blogId) && (
                           <div className={style.main}>
-                            <ModerationQueue database={database} hideMain={this.hideMain} {...props} />
+                            <ModerationQueue hideMain={this.hideMain} {...props} />
                           </div>
                         )}
                       />
                       <Route path="/blog/:blogId/post/:postId"
                         render={props => (isShowMain || props.match.params.postId) && (
                           <div className={style.main}>
-                            <Post database={database} hideMain={this.hideMain} {...props} />
+                            <Post hideMain={this.hideMain} {...props} />
                           </div>
                         )}
                       />
@@ -121,4 +121,4 @@ class Root extends Component {
   }
 }
 
-export default Root
+export default withDatabase(Root)

--- a/examples/web/src/index.js
+++ b/examples/web/src/index.js
@@ -5,6 +5,7 @@ import { render } from 'react-dom'
 
 import { Database } from '@nozbe/watermelondb'
 import LokiJSAdapter from '@nozbe/watermelondb/adapters/lokijs'
+import DatabaseProvider from '@nozbe/watermelondb/DatabaseProvider'
 
 import { mySchema } from 'models/schema'
 import Blog from 'models/Blog'
@@ -24,4 +25,8 @@ const database = new Database({
   actionsEnabled: true,
 })
 
-render(<Root database={database} />, document.getElementById('application'))
+render(
+  <DatabaseProvider database={database}>
+    <Root />
+  </DatabaseProvider>, document.getElementById('application')
+)


### PR DESCRIPTION
As suggested in #141 this PR updates the web example to use `withDatabase` and `DatabaseContext`. This reduces the `database` prop drilling.

Everything else, especially the native demo, is untouched.