### PR TITLE
Fix observeWithColumns glitches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this project will be documented in this file.
 
 This is a **massive** new update to WatermelonDB! 🍉
 
-- **3x faster sync**. We've made big improvements to performance. In our tests, a massive sync
-  (first login, 65K records / 45MB of data) sped up from ~4s to 1.2s on web. Most of what's left is
+- **5x faster sync**. We've made big improvements to performance. In our tests, a massive sync
+  (first login, 65K records / 45MB of data) sped up from 5.7s to 1.2s on web. Most of what's left is
   native IndexedDB and LokiJS indexing overhead and will be more difficult to overcome… but we think
   a few hundred miliseconds more is possible!
 - **Improved LokiJS adapter**. Option to disable web workers, important Safari 13 fix, better performance,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This is a **massive** new update to WatermelonDB! 🍉
 - [Performance][LokiJS] Various performance improvements
 - [Performance][Sync] Make Sync faster
 - [Performance] Make observation faster
+- Fix app glitches and performance issues caused by race conditions in `Query.observeWithColumns()`
 - [LokiJS] Persistence adapter will now be automatically selected based on availability. By default,
   IndexedDB is used. But now, if unavailable (e.g. in private mode), ephemeral memory adapter will be used.
 - [adapters] The adapters interface has changed. `query()` and `count()` methods now receive a `SerializedQuery`, and `batch()` now takes `TableName<any>` and `RawRecord` or `RecordId` instead of `Model`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nozbe/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "0.15.0-4",
+  "version": "0.15.0-5",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/src/Query/index.js
+++ b/src/Query/index.js
@@ -11,7 +11,7 @@ import lazy from '../decorators/lazy' // import from decorarators break the app 
 
 import observeCount from '../observation/observeCount'
 import observeQuery from '../observation/observeQuery'
-import fieldObserver from '../observation/fieldObserver'
+import observeQueryWithColumns from '../observation/observeQueryWithColumns'
 import { buildQueryDescription, queryWithoutDeleted } from '../QueryDescription'
 import type { Condition, QueryDescription } from '../QueryDescription'
 import type Model, { AssociationInfo } from '../Model'
@@ -75,9 +75,10 @@ export default class Query<Record: Model> {
   }
 
   // Same as `observe()` but also emits the list when any of the records
-  // on the list has one of `rawFields` chaged
-  observeWithColumns(rawFields: ColumnName[]): Observable<Record[]> {
-    return fieldObserver(this.observe(), rawFields, this.collection)
+  // on the list has one of `columnNames` chaged
+  observeWithColumns(columnNames: ColumnName[]): Observable<Record[]> {
+    // TODO: Would be nice to cache this
+    return observeQueryWithColumns(this, columnNames)
   }
 
   // Returns the number of matching records

--- a/src/Query/index.js
+++ b/src/Query/index.js
@@ -77,7 +77,7 @@ export default class Query<Record: Model> {
   // Same as `observe()` but also emits the list when any of the records
   // on the list has one of `rawFields` chaged
   observeWithColumns(rawFields: ColumnName[]): Observable<Record[]> {
-    return fieldObserver(this.observe(), rawFields)
+    return fieldObserver(this.observe(), rawFields, this.collection)
   }
 
   // Returns the number of matching records

--- a/src/observation/fieldObserver/test.js
+++ b/src/observation/fieldObserver/test.js
@@ -2,27 +2,18 @@ import { Subject } from 'rxjs/Subject'
 import { mockDatabase } from '../../__tests__/testModels'
 import fieldObserver from './index'
 
-const makeDatabase = () => {
-  // TODO: Change test to actually go through the DB
-  const { database } = mockDatabase()
-
-  database.adapter = {
-    batch: jest.fn(),
-  }
-
-  return database
-}
-
-const mockTask = (database, name, isCompleted, position) =>
-  database.collections.get('mock_tasks').create(mock => {
+const createTask = (tasks, name, isCompleted, position) =>
+  tasks.create(mock => {
     mock.name = name
     mock.isCompleted = isCompleted
     mock.position = position
   })
 
+const updateTask = (task, updater) => task.collection.database.action(() => task.update(updater))
+
 describe('fieldObserver', () => {
   it('observes changes correctly', async () => {
-    const database = makeDatabase()
+    const { database, tasks } = mockDatabase({ actionsEnabled: true })
 
     // start observing
     const source = new Subject()
@@ -30,33 +21,37 @@ describe('fieldObserver', () => {
     const subscription = fieldObserver(source, ['is_completed', 'position']).subscribe(observer)
 
     // start with a few matching models
-    const m1 = await mockTask(database, 'name1', false, 10)
-    const m2 = await mockTask(database, 'name2', false, 20)
+    let m1
+    let m2
+    await database.action(async () => {
+      m1 = await createTask(tasks, 'name1', false, 10)
+      m2 = await createTask(tasks, 'name2', false, 20)
+    })
     source.next([m1, m2])
     expect(observer).toHaveBeenCalledWith([m1, m2])
     expect(observer).toHaveBeenCalledTimes(1)
 
     // add matches, remove matches
-    const m3 = await mockTask(database, 'name3', false, 30)
+    const m3 = await database.action(() => createTask(tasks, 'name3', false, 30))
     source.next([m2, m3])
     expect(observer).toHaveBeenCalledWith([m2, m3])
     expect(observer).toHaveBeenCalledTimes(2)
 
     // make some irrelevant changes (no emission)
-    await m3.update(mock => {
+    await updateTask(m3, mock => {
       mock.name = 'changed name'
     })
     expect(observer).toHaveBeenCalledTimes(2)
 
     // change a relevant field
-    await m3.update(mock => {
+    await updateTask(m3, mock => {
       mock.position += 1
     })
     expect(observer).toHaveBeenCalledWith([m2, m3])
     expect(observer).toHaveBeenCalledTimes(3)
 
     // change another relevant field
-    await m2.update(mock => {
+    await updateTask(m2, mock => {
       mock.isCompleted = true
     })
 
@@ -64,17 +59,17 @@ describe('fieldObserver', () => {
     expect(observer).toHaveBeenCalledTimes(4)
 
     // change a relevant field in a previously-observed record (no emission)
-    await m1.update(mock => {
+    await updateTask(m1, mock => {
       mock.position += 1
     })
     expect(observer).toHaveBeenCalledTimes(4)
 
     // ensure record subscriptions are disposed properly
     source.complete()
-    await m2.update(mock => {
+    await updateTask(m2, mock => {
       mock.position += 1
     })
-    await m3.update(mock => {
+    await updateTask(m3, mock => {
       mock.position += 1
     })
     subscription.unsubscribe()

--- a/src/observation/fieldObserver/test.js
+++ b/src/observation/fieldObserver/test.js
@@ -27,7 +27,9 @@ describe('fieldObserver', () => {
     // start observing
     const source = new Subject()
     const observer = jest.fn()
-    const subscription = fieldObserver(source, ['is_completed', 'position']).subscribe(observer)
+    const subscription = fieldObserver(source, ['is_completed', 'position'], tasks).subscribe(
+      observer,
+    )
 
     // start with a few matching models
     let m1
@@ -89,7 +91,9 @@ describe('fieldObserver', () => {
 
     // start observing
     const observer = jest.fn()
-    const subscription = fieldObserver(source, ['is_completed', 'position']).subscribe(observer)
+    const subscription = fieldObserver(source, ['is_completed', 'position'], tasks).subscribe(
+      observer,
+    )
 
     const waitForNextQuery = () => tasks.query().fetch()
     await waitForNextQuery() // wait for initial query to go through

--- a/src/observation/fieldObserver/test.js
+++ b/src/observation/fieldObserver/test.js
@@ -1,4 +1,3 @@
-import { Subject } from 'rxjs/Subject'
 import { mockDatabase } from '../../__tests__/testModels'
 import * as Q from '../../QueryDescription'
 import fieldObserver from './index'
@@ -21,79 +20,17 @@ const createTask = async (tasks, name, isCompleted, position) => {
 const updateTask = (task, updater) => task.collection.database.action(() => task.update(updater))
 
 describe('fieldObserver', () => {
-  it('observes changes correctly - simulated unit test', async () => {
-    const { database, tasks } = mockDatabase({ actionsEnabled: true })
-
-    // start observing
-    const source = new Subject()
-    const observer = jest.fn()
-    const subscription = fieldObserver(source, ['is_completed', 'position'], tasks).subscribe(
-      observer,
-    )
-
-    // start with a few matching models
-    let m1
-    let m2
-    await database.action(async () => {
-      m1 = await createTask(tasks, 'name1', false, 10)
-      m2 = await createTask(tasks, 'name2', false, 20)
-    })
-    source.next([m1, m2])
-    expect(observer).toHaveBeenLastCalledWith([m1, m2])
-    expect(observer).toHaveBeenCalledTimes(1)
-
-    // add matches, remove matches
-    const m3 = await database.action(() => createTask(tasks, 'name3', false, 30))
-    source.next([m2, m3])
-    expect(observer).toHaveBeenLastCalledWith([m2, m3])
-    expect(observer).toHaveBeenCalledTimes(2)
-
-    // make some irrelevant changes (no emission)
-    await updateTask(m3, mock => {
-      mock.name = 'changed name'
-    })
-    expect(observer).toHaveBeenCalledTimes(2)
-
-    // change a relevant field
-    await updateTask(m3, mock => {
-      mock.position += 1
-    })
-    expect(observer).toHaveBeenLastCalledWith([m2, m3])
-    expect(observer).toHaveBeenCalledTimes(3)
-
-    // change another relevant field
-    await updateTask(m2, mock => {
-      mock.isCompleted = true
-    })
-
-    expect(observer).toHaveBeenLastCalledWith([m2, m3])
-    expect(observer).toHaveBeenCalledTimes(4)
-
-    // change a relevant field in a previously-observed record (no emission)
-    await updateTask(m1, mock => {
-      mock.position += 1
-    })
-    expect(observer).toHaveBeenCalledTimes(4)
-
-    // ensure record subscriptions are disposed properly
-    source.complete()
-    await updateTask(m2, mock => {
-      mock.position += 1
-    })
-    await updateTask(m3, mock => {
-      mock.position += 1
-    })
-    subscription.unsubscribe()
-    expect(observer).toHaveBeenCalledTimes(4)
-  })
-  async function fullObservationTest(mockDb, source, asyncObserver) {
+  async function fullObservationTest(mockDb, source, asyncSource) {
     const { database, tasks } = mockDb
 
     // start observing
     const observer = jest.fn()
-    const subscription = fieldObserver(source, ['is_completed', 'position'], tasks).subscribe(
-      observer,
-    )
+    const subscription = fieldObserver(
+      source,
+      ['is_completed', 'position'],
+      tasks,
+      asyncSource,
+    ).subscribe(observer)
 
     const waitForNextQuery = () => tasks.query().fetch()
     await waitForNextQuery() // wait for initial query to go through
@@ -112,30 +49,37 @@ describe('fieldObserver', () => {
       await database.batch(m1, prepareTask(tasks, 'name_irrelevant', false, 30), m2, m3)
     })
 
-    asyncObserver && (await waitForNextQuery())
+    asyncSource && (await waitForNextQuery())
     expect(observer).toHaveBeenCalledTimes(2)
     expect(observer).toHaveBeenLastCalledWith([m1, m2])
 
     // add matching model
     const m4 = await database.action(() => createTask(tasks, 'name4', true, 40))
 
-    asyncObserver && (await waitForNextQuery())
+    asyncSource && (await waitForNextQuery())
     expect(observer).toHaveBeenCalledTimes(3)
     expect(observer).toHaveBeenLastCalledWith([m1, m2, m4])
 
     // remove matching model
     await database.action(() => m1.markAsDeleted())
 
-    asyncObserver && (await waitForNextQuery())
+    asyncSource && (await waitForNextQuery())
     expect(observer).toHaveBeenCalledTimes(4)
     expect(observer).toHaveBeenLastCalledWith([m2, m4])
+
+    // some irrelevant change (no emission)
+    await updateTask(m2, task => {
+      task.name = 'changed name'
+    })
+    asyncSource && (await waitForNextQuery())
+    expect(observer).toHaveBeenCalledTimes(4)
 
     // change model to start matching
     await updateTask(m3, task => {
       task.isCompleted = true
     })
 
-    asyncObserver && (await waitForNextQuery())
+    asyncSource && (await waitForNextQuery())
     expect(observer).toHaveBeenCalledTimes(5)
     expect(observer.mock.calls[4][0]).toHaveLength(3)
     expect(observer.mock.calls[4][0]).toEqual(expect.arrayContaining([m2, m3, m4]))
@@ -146,17 +90,16 @@ describe('fieldObserver', () => {
       task.isCompleted = false
     })
 
-    asyncObserver && (await waitForNextQuery())
+    asyncSource && (await waitForNextQuery())
     expect(observer).toHaveBeenCalledTimes(6)
     expect(observer.mock.calls[5][0]).toHaveLength(2)
     expect(observer.mock.calls[5][0]).toEqual(expect.arrayContaining([m3, m4]))
 
-    // make an irrelevant change to observed records - expect no change
+    // change a relevant field in previously-observed record (no emission)
     await updateTask(m2, task => {
-      task.position = 50
+      task.position = 10
     })
-
-    asyncObserver && (await waitForNextQuery())
+    asyncSource && (await waitForNextQuery())
     expect(observer).toHaveBeenCalledTimes(6)
 
     // make multiple simultaneous changes to observed records - expect only one emission
@@ -175,19 +118,31 @@ describe('fieldObserver', () => {
       ),
     )
 
-    asyncObserver && (await waitForNextQuery())
+    asyncSource && (await waitForNextQuery())
     expect(observer).toHaveBeenCalledTimes(7)
     expect(observer.mock.calls[6][0]).toEqual(observer.mock.calls[5][0])
 
-    subscription.unsubscribe()
+    // make an irrelevant change to recently changed record (no emission)
+    // Note: This is a regression check for a situation where task had a relevant change,
+    // but new record state was not cached, so another irrelevant change triggered an update
+    await updateTask(m4, task => {
+      task.name = 'different name'
+    })
+    asyncSource && (await waitForNextQuery())
+    expect(observer).toHaveBeenCalledTimes(7)
 
+    // ensure record subscriptions are disposed properly
+    subscription.unsubscribe()
+    await updateTask(m3, mock => {
+      mock.position += 1
+    })
     expect(observer).toHaveBeenCalledTimes(7)
   }
   it('observes changes correctly - test with simple observer', async () => {
     const mockDb = mockDatabase({ actionsEnabled: true })
     const query = mockDb.tasks.query(Q.where('is_completed', true))
-    const source = simpleObserver(query)
-    await fullObservationTest(mockDb, source)
+    const source = simpleObserver(query, true)
+    await fullObservationTest(mockDb, source, false)
   })
   it('observes changes correctly - test with reloading observer', async () => {
     const mockDb = mockDatabase({ actionsEnabled: true })

--- a/src/observation/fieldObserver/test.js
+++ b/src/observation/fieldObserver/test.js
@@ -3,7 +3,7 @@ import { mockDatabase } from '../../__tests__/testModels'
 import * as Q from '../../QueryDescription'
 import fieldObserver from './index'
 import simpleObserver from '../simpleObserver'
-import reloadingObserver from '../reloadingObserver'
+import { reloadingObserverWithStatus } from '../reloadingObserver'
 
 const prepareTask = (tasks, name, isCompleted, position) =>
   tasks.prepareCreate(mock => {
@@ -147,7 +147,8 @@ describe('fieldObserver', () => {
   it('observes changes correctly - test with reloading observer', async () => {
     const mockDb = mockDatabase({ actionsEnabled: true })
     const query = mockDb.tasks.query(Q.where('is_completed', true))
-    const source = reloadingObserver(query)
+    const source = reloadingObserverWithStatus(query)
     await fullObservationTest(mockDb, source, true)
+    // TODO: Move these to Collection, test for distinctUntilChanged
   })
 })

--- a/src/observation/fieldObserver/test.js
+++ b/src/observation/fieldObserver/test.js
@@ -147,6 +147,14 @@ describe('fieldObserver', () => {
     expect(observer.mock.calls[5][0]).toHaveLength(2)
     expect(observer.mock.calls[5][0]).toEqual(expect.arrayContaining([m3, m4]))
 
+    // make an irrelevant change to observed records - expect no change
+    await updateTask(m2, task => {
+      task.position = 50
+    })
+
+    asyncObserver && (await waitForNextQuery())
+    expect(observer).toHaveBeenCalledTimes(6)
+
     // make multiple simultaneous changes to observed records - expect only one emission
     await database.action(() =>
       database.batch(

--- a/src/observation/observeQueryWithColumns/test.js
+++ b/src/observation/observeQueryWithColumns/test.js
@@ -1,6 +1,6 @@
 import { mockDatabase } from '../../__tests__/testModels'
 import * as Q from '../../QueryDescription'
-import fieldObserver from './index'
+import observeQueryWithColumns from './index'
 
 const prepareTask = (tasks, name, isCompleted, position) =>
   tasks.prepareCreate(mock => {
@@ -18,7 +18,7 @@ const createTask = async (tasks, name, isCompleted, position) => {
 
 const updateTask = (task, updater) => task.collection.database.action(() => task.update(updater))
 
-describe('fieldObserver', () => {
+describe('observeQueryWithColumns', () => {
   async function fullObservationTest(mockDb, query, asyncSource) {
     const { database, tasks, projects } = mockDb
 
@@ -29,7 +29,7 @@ describe('fieldObserver', () => {
 
     // start observing
     const observer = jest.fn()
-    const subscription = fieldObserver(query, [('is_completed', 'position')]).subscribe(observer)
+    const subscription = observeQueryWithColumns(query, [('is_completed', 'position')]).subscribe(observer)
 
     const waitForNextQuery = () => tasks.query().fetch()
     await waitForNextQuery() // wait for initial query to go through

--- a/src/observation/reloadingObserver.js
+++ b/src/observation/reloadingObserver.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Observable } from 'rxjs/Observable'
-import { switchMap, distinctUntilChanged, startWith, filter as filter$ } from 'rxjs/operators'
+import { switchMap, distinctUntilChanged, startWith } from 'rxjs/operators'
 import { from } from 'rxjs/observable/from'
 
 import identicalArrays from '../utils/fp/identicalArrays'
@@ -13,23 +13,20 @@ import type Model from '../Model'
 // when any change occurs in any of the relevant Stores.
 // This is inefficient for simple queries, but necessary for complex queries
 
-export function reloadingObserverWithStatus<Record: Model>(
-  query: Query<Record>,
-): Observable<Record[] | false> {
-  const { database } = query.collection
-
-  return database
-    .withChangesForTables(query.allTables)
-    .pipe(switchMap(() => from(query.collection.fetchQuery(query)).pipe(startWith(false))))
-}
-
 export default function reloadingObserver<Record: Model>(
   query: Query<Record>,
+  // Emits `false` when query fetch begins + always emits even if no change - internal trick needed
+  // by observeWithColumns
+  shouldEmitStatus: boolean = false,
 ): Observable<Record[]> {
-  return reloadingObserverWithStatus(query)
-    .pipe(
-      (filter$(value => value !== false): $FlowFixMe<
-        (Observable<Record[] | false>) => Observable<Record[]>,>),
-    )
-    .pipe(distinctUntilChanged(identicalArrays))
+  const reloadingQuery = query.collection.database.withChangesForTables(query.allTables).pipe(
+    switchMap(() => {
+      const queryPromise = query.collection.fetchQuery(query)
+      return shouldEmitStatus ? from(queryPromise).pipe(startWith((false: any))) : queryPromise
+    }),
+  )
+
+  return shouldEmitStatus
+    ? reloadingQuery
+    : reloadingQuery.pipe(distinctUntilChanged(identicalArrays))
 }

--- a/src/observation/simpleObserver/index.js
+++ b/src/observation/simpleObserver/index.js
@@ -54,7 +54,7 @@ export function processChangeSet<Record: Model>(
 
 function observeChanges<Record: Model>(
   query: Query<Record>,
-  alwaysEmit,
+  alwaysEmit: boolean,
 ): (Record[]) => Observable<Record[]> {
   const matcher: Matcher<Record> = encodeMatcher(query.description)
 
@@ -77,6 +77,8 @@ function observeChanges<Record: Model>(
 
 export default function simpleObserver<Record: Model>(
   query: Query<Record>,
+  // if true, emissions will always be made on collection change -- this is an internal hack needed by
+  // observeQueryWithColumns
   alwaysEmit: boolean = false,
 ): Observable<Record[]> {
   return defer(() => query.collection.fetchQuery(query)).pipe(

--- a/src/observation/simpleObserver/index.js
+++ b/src/observation/simpleObserver/index.js
@@ -16,7 +16,8 @@ import type Model from '../../Model'
 
 import encodeMatcher, { type Matcher } from '../encodeMatcher'
 
-function processChangeSet<Record: Model>(
+// WARN: Mutates arguments
+export function processChangeSet<Record: Model>(
   changeSet: CollectionChangeSet<Record>,
   matcher: Matcher<Record>,
   mutableMatchingRecords: Record[],
@@ -51,28 +52,35 @@ function processChangeSet<Record: Model>(
   return shouldEmit
 }
 
-function observeChanges<Record: Model>(query: Query<Record>): (Record[]) => Observable<Record[]> {
+function observeChanges<Record: Model>(
+  query: Query<Record>,
+  alwaysEmit,
+): (Record[]) => Observable<Record[]> {
   const matcher: Matcher<Record> = encodeMatcher(query.description)
 
   return initialRecords =>
     Observable.create(observer => {
       // Send initial matching records
       const matchingRecords: Record[] = initialRecords
-      const emit = () => observer.next(matchingRecords.slice(0))
-      emit()
+      const emitCopy = () => observer.next(matchingRecords.slice(0))
+      emitCopy()
 
       // Observe changes to the collection
       return query.collection.changes.subscribe(changeSet => {
-        if (processChangeSet(changeSet, matcher, matchingRecords)) {
-          emit()
+        const shouldEmit = processChangeSet(changeSet, matcher, matchingRecords)
+        if (shouldEmit || alwaysEmit) {
+          emitCopy()
         }
       })
     })
 }
 
-export default function simpleObserver<Record: Model>(query: Query<Record>): Observable<Record[]> {
+export default function simpleObserver<Record: Model>(
+  query: Query<Record>,
+  alwaysEmit: boolean = false,
+): Observable<Record[]> {
   return defer(() => query.collection.fetchQuery(query)).pipe(
-    switchMap(observeChanges(query)),
+    switchMap(observeChanges(query, alwaysEmit)),
     doOnSubscribe(() => logger.log(`Subscribed to changes in a ${query.table} query`)),
     doOnDispose(() => logger.log(`Unsubscribed from changes in a ${query.table} query`)),
   )


### PR DESCRIPTION
- [x] fixes fieldObserver / observeWithColumns race condition which caused weird glitches - e.g. in NT when removing a star from task in Priority, task would first go to the bottom, only then disappear