### PR TITLE
Fast login - Android (fail)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This is a **massive** new update to WatermelonDB! 🍉
 - [Performance] [LokiJS] Various performance improvements
 - [Performance] [Sync] Make Sync faster
 - [Performance] Make observation faster
+- [Performance] [Android] Make batches faster
 - Fix app glitches and performance issues caused by race conditions in `Query.observeWithColumns()`
 - [LokiJS] Persistence adapter will now be automatically selected based on availability. By default,
   IndexedDB is used. But now, if unavailable (e.g. in private mode), ephemeral memory adapter will be used.

--- a/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
@@ -32,12 +32,18 @@ class Database(private val name: String, private val context: Context) {
                 }
             }
 
-    fun execute(query: SQL, values: QueryArgs = arrayListOf()) =
-            db.execSQL(query, values.toArray())
+    fun execute(query: SQL, args: QueryArgs = emptyArray()) =
+            db.execSQL(query, args)
 
-    fun delete(query: SQL, queryArgs: QueryArgs) = db.execSQL(query, queryArgs.toArray())
+    fun delete(query: SQL, args: QueryArgs) = db.execSQL(query, args)
 
-    fun rawQuery(query: SQL, key: RawQueryArgs = emptyArray()): Cursor = db.rawQuery(query, key)
+    fun rawQuery(query: SQL, args: RawQueryArgs = emptyArray()): Cursor = db.rawQuery(query, args)
+
+    fun count(query: SQL, args: RawQueryArgs = emptyArray()): Int =
+            rawQuery(query, args).use {
+                it.moveToFirst()
+                return it.getInt(it.getColumnIndex("count"))
+            }
 
     fun getFromLocalStorage(key: String): String? =
             rawQuery(Queries.select_local_storage, arrayOf(key)).use {
@@ -50,16 +56,10 @@ class Database(private val name: String, private val context: Context) {
             }
 
     fun insertToLocalStorage(key: String, value: String) =
-            execute(Queries.insert_local_storage, arrayListOf(key, value))
+            execute(Queries.insert_local_storage, arrayOf(key, value))
 
     fun deleteFromLocalStorage(key: String) =
-            execute(Queries.delete_local_storage, arrayListOf(key))
-
-    fun count(query: SQL, values: RawQueryArgs = emptyArray()): Int =
-            rawQuery(query, values).use {
-                it.moveToFirst()
-                return it.getInt(it.getColumnIndex("count"))
-            }
+            execute(Queries.delete_local_storage, arrayOf(key))
 
 //    fun unsafeResetDatabase() = context.deleteDatabase("$name.db")
 

--- a/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
@@ -1,7 +1,6 @@
 package com.nozbe.watermelondb
 
 import android.database.SQLException
-import android.os.Debug
 import android.os.Trace
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -9,10 +8,6 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.Arguments
-import com.nozbe.watermelondb.DatabaseDriver.Operation
-import java.text.SimpleDateFormat
-import java.util.*
-import java.util.logging.Logger
 import kotlin.collections.ArrayList
 
 class DatabaseBridge(private val reactContext: ReactApplicationContext) :

--- a/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
@@ -12,6 +12,7 @@ import com.facebook.react.bridge.Arguments
 import com.nozbe.watermelondb.DatabaseDriver.Operation
 import java.text.SimpleDateFormat
 import java.util.*
+import java.util.logging.Logger
 import kotlin.collections.ArrayList
 
 class DatabaseBridge(private val reactContext: ReactApplicationContext) :
@@ -129,22 +130,8 @@ class DatabaseBridge(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun batch(tag: ConnectionTag, operations: ReadableArray, promise: Promise) =
-            withDriver(tag, promise) {
-                val dateFormat = SimpleDateFormat("dd_MM_yyyy_hh_mm_ss", Locale.getDefault())
-                val logDate = dateFormat.format(Date())
-                val shouldTrace = operations.size() >= 2000
+            withDriver(tag, promise) { it.batch(operations) }
 
-                if (shouldTrace) {
-                    Debug.startMethodTracingSampling("sample-$logDate", 10*1024*1024, 500)
-                }
-
-                val ret = it.batchOptimized(operations)
-
-                if (shouldTrace) {
-                    Debug.stopMethodTracing()
-                }
-                return@withDriver ret
-            }
     @ReactMethod
     fun getDeletedRecords(tag: ConnectionTag, table: TableName, promise: Promise) =
             withDriver(tag, promise) { it.getDeletedRecords(table) }

--- a/native/android/src/main/java/com/nozbe/watermelondb/DatabaseDriver.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/DatabaseDriver.kt
@@ -131,7 +131,7 @@ class DatabaseDriver(context: Context, dbName: String) {
         database.execute(query, args)
     }
 
-    fun batchOptimized(operations: ReadableArray) {
+    fun batch(operations: ReadableArray) {
         log?.info("Batch of ${operations.size()}")
         val newIds = arrayListOf<Pair<TableName, RecordID>>()
         val removedIds = arrayListOf<Pair<TableName, RecordID>>()

--- a/native/android/src/main/java/com/nozbe/watermelondb/DatabaseUtils.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/DatabaseUtils.kt
@@ -6,7 +6,7 @@ import com.facebook.react.bridge.WritableMap
 typealias SQL = String
 typealias RecordID = String
 typealias TableName = String
-typealias QueryArgs = ArrayList<Any>
+typealias QueryArgs = Array<Any>
 typealias RawQueryArgs = Array<String>
 typealias ConnectionTag = Int
 typealias SchemaVersion = Int

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nozbe/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "0.15.0-6",
+  "version": "0.15.0-7",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/scripts/make.js
+++ b/scripts/make.js
@@ -149,9 +149,16 @@ if (isDevelopment) {
   copyNonJavaScriptFiles(DEV_PATH)
 
   chokidar
-    .watch([resolvePath('src'), resolvePath('native/ios/WatermelonDB')], {
-      ignored: DO_NOT_BUILD_PATHS,
-    })
+    .watch(
+      [
+        resolvePath('src'),
+        resolvePath('native/ios/WatermelonDB'),
+        resolvePath('native/android/src/main'),
+      ],
+      {
+        ignored: DO_NOT_BUILD_PATHS,
+      },
+    )
     .on('all', (event, fileOrDir) => {
       // eslint-disable-next-line
       switch (event) {


### PR DESCRIPTION
Trying to do some quick profiling and optimizations on Android has been a total failure :(

I wasted most of yesterday trying to figure out how to do any sort of profiling… and still it's shit compared to Instruments / web inspector.

I'm not sure if these changes have any real impact in the end. CPU tracing suggested that it should give a ~2x speedup… but, after making a before/after NT build, I don't see a difference in login time. Don't know where I went wrong - giving up for now.

- commented out debug logs on inserts… 130000 console logs is not something you want on login, even in debug
- ArrayList → Array -- sql arguments are immutable and the array size is known, so we can skip some overhead
- got rid of ReadableArray.toOperationsList in favor of decoding ReadableArray directly in DatabaseDriver. It's less clean but CPU traces suggested 40% of batch time is wasted repackaging data in this way
- added some systrace traces for future debugging