### PR TITLE
Perf improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ This is a **massive** new update to WatermelonDB! 🍉
 - Fix app glitches and performance issues caused by race conditions in `Query.observeWithColumns()`
 - [LokiJS] Persistence adapter will now be automatically selected based on availability. By default,
   IndexedDB is used. But now, if unavailable (e.g. in private mode), ephemeral memory adapter will be used.
+- Disabled console logs regarding new observations (it never actually counted all observations) and
+  time to query/count/batch (the measures were wildly inaccurate because of asynchronicity - actual
+  times are much lower)
+- Improved debuggability of Watermelon -- shortened Rx stacks and added function names to aid in understanding
+  call stacks and profiles
 - [adapters] The adapters interface has changed. `query()` and `count()` methods now receive a `SerializedQuery`, and `batch()` now takes `TableName<any>` and `RawRecord` or `RecordId` instead of `Model`.
 - [Typescript] Typing improvements
      - Added 3 missing properties `collections`, `database` and `asModel` in Model type definition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ This is a **massive** new update to WatermelonDB! 🍉
 - Disabled console logs regarding new observations (it never actually counted all observations) and
   time to query/count/batch (the measures were wildly inaccurate because of asynchronicity - actual
   times are much lower)
+- [withObservables] Improved performance and debuggability (update withObservables package separately)
 - Improved debuggability of Watermelon -- shortened Rx stacks and added function names to aid in understanding
   call stacks and profiles
 - [adapters] The adapters interface has changed. `query()` and `count()` methods now receive a `SerializedQuery`, and `batch()` now takes `TableName<any>` and `RawRecord` or `RecordId` instead of `Model`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nozbe/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "0.15.0-7",
+  "version": "0.15.0-8",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/src/adapters/common.js
+++ b/src/adapters/common.js
@@ -10,6 +10,8 @@ import { sanitizedRaw, type DirtyRaw } from '../RawRecord'
 export type DirtyFindResult = RecordId | ?DirtyRaw
 export type DirtyQueryResult = Array<RecordId | DirtyRaw>
 
+const shouldLogAdapterTimes = false
+
 export function validateAdapter(adapter: DatabaseAdapter): void {
   if (process.env.NODE_ENV !== 'production') {
     const { schema, migrations } = adapter
@@ -69,7 +71,7 @@ export async function devLogFind(
   table: string,
 ): Promise<CachedFindResult> {
   const [data, time] = await devMeasureTimeAsync(executeBlock)
-  logger.log(`[DB] Found ${table}#${id} in ${time}ms`)
+  shouldLogAdapterTimes && logger.log(`[DB] Found ${table}#${id} in ${time}ms`)
   return data
 }
 
@@ -78,7 +80,8 @@ export async function devLogQuery(
   query: SerializedQuery,
 ): Promise<CachedQueryResult> {
   const [dirtyRecords, time] = await devMeasureTimeAsync(executeBlock)
-  logger.log(`[DB] Loaded ${dirtyRecords.length} ${query.table} in ${time}ms`)
+  shouldLogAdapterTimes &&
+    logger.log(`[DB] Loaded ${dirtyRecords.length} ${query.table} in ${time}ms`)
   return dirtyRecords
 }
 
@@ -87,7 +90,7 @@ export async function devLogCount(
   query: SerializedQuery,
 ): Promise<number> {
   const [count, time] = await devMeasureTimeAsync(executeBlock)
-  logger.log(`[DB] Counted ${count} ${query.table} in ${time}ms`)
+  shouldLogAdapterTimes && logger.log(`[DB] Counted ${count} ${query.table} in ${time}ms`)
   return count
 }
 
@@ -100,7 +103,8 @@ export async function devLogBatch<T>(
   }
   const [, time] = await devMeasureTimeAsync(executeBlock)
   const [type, table] = operations[0]
-  logger.log(
-    `[DB] Executed batch of ${operations.length} operations (first: ${type} on ${table}) in ${time}ms`,
-  )
+  shouldLogAdapterTimes &&
+    logger.log(
+      `[DB] Executed batch of ${operations.length} operations (first: ${type} on ${table}) in ${time}ms`,
+    )
 }

--- a/src/adapters/lokijs/worker/queue.js
+++ b/src/adapters/lokijs/worker/queue.js
@@ -19,7 +19,7 @@ function createQueueTask<Input, Output>(
   callback: QueueWorkerCallback<Output>,
 ): Observable<any> {
   return Observable.create(observer => {
-    worker(data, result => {
+    worker(data, function lokiWorkerQueueReaction(result): void {
       observer.next(data)
       callback(result)
       observer.complete()

--- a/src/adapters/lokijs/worker/workerMock.js
+++ b/src/adapters/lokijs/worker/workerMock.js
@@ -32,7 +32,9 @@ export default class LokiWorkerMock {
     this._workerContext = {
       postMessage: data => {
         const clonedData = clone(data)
-        setImmediate(() => {
+
+        // Schedule on the microtask queue to be able to achieve synchronous, glitch-free rendering
+        Promise.resolve().then(() => {
           this.onmessage({ data: clonedData })
         })
       },
@@ -58,7 +60,7 @@ export default class LokiWorkerMock {
       clonedData = clone(data)
     }
 
-    setImmediate(() => {
+    Promise.resolve().then(() => {
       // $FlowFixMe
       this._workerContext.onmessage({ data: clonedData })
     })

--- a/src/observation/simpleObserver/index.js
+++ b/src/observation/simpleObserver/index.js
@@ -66,7 +66,9 @@ function observeChanges<Record: Model>(
       emitCopy()
 
       // Observe changes to the collection
-      return query.collection.changes.subscribe(changeSet => {
+      return query.collection.changes.subscribe(function observeQueryCollectionChanged(
+        changeSet,
+      ): void {
         const shouldEmit = processChangeSet(changeSet, matcher, matchingRecords)
         if (shouldEmit || alwaysEmit) {
           emitCopy()

--- a/src/observation/simpleObserver/index.js
+++ b/src/observation/simpleObserver/index.js
@@ -1,13 +1,8 @@
 // @flow
 
 import { Observable } from 'rxjs/Observable'
-import { defer } from 'rxjs/observable/defer'
-import { switchMap } from 'rxjs/operators'
 
-import doOnDispose from '../../utils/rx/doOnDispose'
-import doOnSubscribe from '../../utils/rx/doOnSubscribe'
-
-import logger from '../../utils/common/logger'
+// import logger from '../../utils/common/logger'
 import type { CollectionChangeSet } from '../../Collection'
 import { CollectionChangeTypes } from '../../Collection/common'
 

--- a/src/observation/simpleObserver/index.js
+++ b/src/observation/simpleObserver/index.js
@@ -59,7 +59,7 @@ function observeChanges<Record: Model>(
   const matcher: Matcher<Record> = encodeMatcher(query.description)
 
   return initialRecords =>
-    Observable.create(observer => {
+    Observable.create(function observeQueryInitialEmission(observer): void {
       // Send initial matching records
       const matchingRecords: Record[] = initialRecords
       const emitCopy = () => observer.next(matchingRecords.slice(0))

--- a/src/observation/simpleObserver/index.js
+++ b/src/observation/simpleObserver/index.js
@@ -61,7 +61,7 @@ export default function simpleObserver<Record: Model>(
   // Note: it would be cleaner to do defer->switchMap, but that makes profiles really hard to read
   // hence the mutability
   return Observable.create(observer => {
-    logger.log(`Subscribing to changes in a ${query.table} query`)
+    // logger.log(`Subscribing to changes in a ${query.table} query`)
 
     const matcher: Matcher<Record> = encodeMatcher(query.description)
     let unsubscribed = false
@@ -93,7 +93,7 @@ export default function simpleObserver<Record: Model>(
     return () => {
       unsubscribed = true
       subscription && subscription.unsubscribe()
-      logger.log(`Unsubscribed from changes in a ${query.table} query`)
+      // logger.log(`Unsubscribed from changes in a ${query.table} query`)
     }
   })
 }

--- a/src/observation/simpleObserver/index.js
+++ b/src/observation/simpleObserver/index.js
@@ -52,40 +52,48 @@ export function processChangeSet<Record: Model>(
   return shouldEmit
 }
 
-function observeChanges<Record: Model>(
-  query: Query<Record>,
-  alwaysEmit: boolean,
-): (Record[]) => Observable<Record[]> {
-  const matcher: Matcher<Record> = encodeMatcher(query.description)
-
-  return initialRecords =>
-    Observable.create(function observeQueryInitialEmission(observer): void {
-      // Send initial matching records
-      const matchingRecords: Record[] = initialRecords
-      const emitCopy = () => observer.next(matchingRecords.slice(0))
-      emitCopy()
-
-      // Observe changes to the collection
-      return query.collection.changes.subscribe(function observeQueryCollectionChanged(
-        changeSet,
-      ): void {
-        const shouldEmit = processChangeSet(changeSet, matcher, matchingRecords)
-        if (shouldEmit || alwaysEmit) {
-          emitCopy()
-        }
-      })
-    })
-}
-
 export default function simpleObserver<Record: Model>(
   query: Query<Record>,
   // if true, emissions will always be made on collection change -- this is an internal hack needed by
   // observeQueryWithColumns
   alwaysEmit: boolean = false,
 ): Observable<Record[]> {
-  return defer(() => query.collection.fetchQuery(query)).pipe(
-    switchMap(observeChanges(query, alwaysEmit)),
-    doOnSubscribe(() => logger.log(`Subscribed to changes in a ${query.table} query`)),
-    doOnDispose(() => logger.log(`Unsubscribed from changes in a ${query.table} query`)),
-  )
+  // Note: it would be cleaner to do defer->switchMap, but that makes profiles really hard to read
+  // hence the mutability
+  return Observable.create(observer => {
+    logger.log(`Subscribing to changes in a ${query.table} query`)
+
+    const matcher: Matcher<Record> = encodeMatcher(query.description)
+    let unsubscribed = false
+    let subscription = null
+
+    query.collection
+      .fetchQuery(query)
+      .then(function observeQueryInitialEmission(initialRecords): void {
+        if (unsubscribed) {
+          return
+        }
+
+        // Send initial matching records
+        const matchingRecords: Record[] = initialRecords
+        const emitCopy = () => observer.next(matchingRecords.slice(0))
+        emitCopy()
+
+        // Observe changes to the collection
+        subscription = query.collection.changes.subscribe(function observeQueryCollectionChanged(
+          changeSet,
+        ): void {
+          const shouldEmit = processChangeSet(changeSet, matcher, matchingRecords)
+          if (shouldEmit || alwaysEmit) {
+            emitCopy()
+          }
+        })
+      })
+
+    return () => {
+      unsubscribed = true
+      subscription && subscription.unsubscribe()
+      logger.log(`Unsubscribed from changes in a ${query.table} query`)
+    }
+  })
 }

--- a/src/observation/simpleObserver/index.js
+++ b/src/observation/simpleObserver/index.js
@@ -2,7 +2,6 @@
 
 import { Observable } from 'rxjs/Observable'
 
-// import logger from '../../utils/common/logger'
 import type { CollectionChangeSet } from '../../Collection'
 import { CollectionChangeTypes } from '../../Collection/common'
 
@@ -56,8 +55,6 @@ export default function simpleObserver<Record: Model>(
   // Note: it would be cleaner to do defer->switchMap, but that makes profiles really hard to read
   // hence the mutability
   return Observable.create(observer => {
-    // logger.log(`Subscribing to changes in a ${query.table} query`)
-
     const matcher: Matcher<Record> = encodeMatcher(query.description)
     let unsubscribed = false
     let subscription = null
@@ -88,7 +85,6 @@ export default function simpleObserver<Record: Model>(
     return () => {
       unsubscribed = true
       subscription && subscription.unsubscribe()
-      // logger.log(`Unsubscribed from changes in a ${query.table} query`)
     }
   })
 }

--- a/src/utils/fp/identicalArrays/index.js
+++ b/src/utils/fp/identicalArrays/index.js
@@ -1,7 +1,16 @@
 // @flow
 
 // bottleneck function without dependencies to optimize performance
-const identicalArrays = <T, V: T[]>(arrayA: V, arrayB: V): boolean =>
-  arrayA.length === arrayB.length && arrayA.every((el, index) => el === arrayB[index])
+export default function identicalArrays<T, V: T[]>(left: V, right: V): boolean {
+  if (left.length !== right.length) {
+    return false
+  }
 
-export default identicalArrays
+  for (let i = 0, len = left.length; i < len; i += 1) {
+    if (left[i] !== right[i]) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/src/utils/fp/identicalArrays/index.js
+++ b/src/utils/fp/identicalArrays/index.js
@@ -1,6 +1,5 @@
 // @flow
 
-// bottleneck function without dependencies to optimize performance
 export default function identicalArrays<T, V: T[]>(left: V, right: V): boolean {
   if (left.length !== right.length) {
     return false

--- a/src/utils/fp/identicalArrays/test.js
+++ b/src/utils/fp/identicalArrays/test.js
@@ -1,0 +1,15 @@
+import identicalArrays from './index'
+
+describe('identicalArrays', () => {
+  it('checks if arrays have identical contents', () => {
+    expect(identicalArrays([], [])).toBe(true)
+    expect(identicalArrays([1], [1])).toBe(true)
+    expect(identicalArrays([true], [true])).toBe(true)
+    expect(identicalArrays(['foo'], ['foo'])).toBe(true)
+    // false
+    expect(identicalArrays(['foo', 'bar'], ['foo'])).toBe(false)
+    expect(identicalArrays(['foo'], ['foo', 'bar'])).toBe(false)
+    expect(identicalArrays(['foo'], ['bar'])).toBe(false)
+    expect(identicalArrays([1], [true])).toBe(false)
+  })
+})

--- a/src/utils/rx/index.js
+++ b/src/utils/rx/index.js
@@ -1,6 +1,6 @@
 // @flow
 
 export { default as cacheWhileConnected } from './cacheWhileConnected'
-export { default as doOnDispose } from './doOnDispose'
-export { default as doOnSubscribe } from './doOnSubscribe'
+// export { default as doOnDispose } from './doOnDispose'
+// export { default as doOnSubscribe } from './doOnSubscribe'
 export { default as publishReplayLatestWhileConnected } from './publishReplayLatestWhileConnected'


### PR DESCRIPTION
- Add function names for Rx observers and other things triggered from microtask queue for easier debugging (hard to understand what's going on in profiles or stack traces when it's just RxJS bullshit and `(anonymous)`)
- Some de-rx-ification of the code. the code looks worse :( … but seriously, rx stack traces are so enormous, it's hard to work with profiles
- disable most logging, because it's useless & slow
- schedule Loki app→executor communication in `useWebWorker: false` mode as Microtasks, not Macrotasks. This way, we can make UI synchronous-ish -- control won't be returned to browser to paint before the response arrives, so we can avoid glitches. In the future, it would be nice to take good advantage of multithreading/concurrency with web workers -- that was a selling feature of 🍉 after all -- but as things stand today, Loki queries are SUPER fast, and rendering is the bottleneck. So doing things synchronously(ish) and on one thread is faster.
