### PR TITLE
Update CRUD.md

### DIFF
--- a/docs-master/CRUD.md
+++ b/docs-master/CRUD.md
@@ -101,7 +101,7 @@ await database.action(async () => {
 - `Collection.findAndObserve(id)` — same as using `.find(id)` and then calling `record.observe()`
 - `Model.prepareUpdate()`, `Collection.prepareCreate`, `Database.batch` — used for [batch updates](./Actions.md)
 - `Database.unsafeResetDatabase()` destroys the whole database - [be sure to see this comment before using it](https://github.com/Nozbe/WatermelonDB/blob/22188ee5b6e3af08e48e8af52d14e0d90db72925/src/Database/index.js#L131)
-- To override the `record.id` during the creation, e.g. to sync with a remote database, you can do it by `record._raw` property
+- To override the `record.id` during the creation, e.g. to sync with a remote database, you can do it by `record._raw` property. Be aware that the `id` must be of type `string`.
 ```js 
 await postsCollection.create(post => {
   post._raw.id = serverId


### PR DESCRIPTION
Mentioning in the CRUD section for overwriting the ID that the ID must be a string (number, which is quite intuitive to use, doesn't work: see issue #214 )