### PR TITLE
Bisynchronous adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 (Low breakage risk)
 
 - [adapters] Adapter API has changed from returning Promise to taking callbacks as the last argument. This won't affect you unless you call on adapter methods directly. `database.adapter` returns a new `DatabaseAdapterCompat` which has the same shape as old adapter API. You can use `database.adapter.underlyingAdapter` to get back `SQLiteAdapter` / `LokiJSAdapter`
-- [Collection]
+- [Collection] `Collection.fetchQuery` and `Collection.fetchCount` are removed. Please use `Query.fetch()` and `Query.fetchCount()`.
 
 ### New features
 
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- [Adapters]
+- [Performance] Watermelon internals have been rewritten not to rely on Promises and allow some fetch/observe calls to resolve synchronously. Do not rely on this -- external API is still based on Rx and Promises and may resolve either asynchronously or synchronously depending on capabilities. This is meant as a internal performance optimization only for the time being.
 - [LokiJS] [Performance] Improved worker queue implementation for performance
 - [observation] Refactored observer implementations for performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### ⚠️ Breaking
+
+(Low breakage risk)
+
+- [adapters] Adapter API has changed from returning Promise to taking callbacks as the last argument. This won't affect you unless you call on adapter methods directly. `database.adapter` returns a new `DatabaseAdapterCompat` which has the same shape as old adapter API. You can use `database.adapter.underlyingAdapter` to get back `SQLiteAdapter` / `LokiJSAdapter`
+- [Collection]
+
 ### New features
 
 - [SQLiteAdapter] [iOS] Add new `synchronous` option to adapter: `new SQLiteAdapter({ ..., synchronous: true })`.
@@ -18,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- [Adapters]
 - [LokiJS] [Performance] Improved worker queue implementation for performance
 - [observation] Refactored observer implementations for performance
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nozbe/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "0.16.0-6",
+  "version": "0.16.0-7",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/src/Collection/index.js
+++ b/src/Collection/index.js
@@ -119,7 +119,12 @@ export default class Collection<Record: Model> {
   _fetchQuery(query: Query<Record>, callback: (Result<Record[]>) => void): void {
     this.database.adapter.underlyingAdapter.query(query.serialize(), result => {
       if (result.value) {
-        callback({ value: this._cache.recordsFromQueryResult(result.value) })
+        try {
+          const value = this._cache.recordsFromQueryResult(result.value)
+          callback({ value })
+        } catch (error) {
+          callback({ error })
+        }
       } else {
         callback(result)
       }
@@ -135,7 +140,12 @@ export default class Collection<Record: Model> {
   _fetchRecord(id: RecordId, callback: (Result<Record>) => void): void {
     this.database.adapter.underlyingAdapter.find(this.table, id, result => {
       if (result.value) {
-        callback({ value: this._cache.recordFromQueryResult(result.value) })
+        try {
+          const value = this._cache.recordFromQueryResult(result.value)
+          callback({ value })
+        } catch (error) {
+          callback({ error })
+        }
       } else {
         callback({ error: new Error(`Record ${this.table}#${id} not found`) })
       }

--- a/src/Collection/test.js
+++ b/src/Collection/test.js
@@ -4,6 +4,8 @@ import { noop } from '../utils/fp'
 import Query from '../Query'
 import * as Q from '../QueryDescription'
 import { logger } from '../utils/common'
+import { toPromise } from '../utils/fp/Result'
+
 import { mockDatabase, MockTask, testSchema } from '../__tests__/testModels'
 
 import { CollectionChangeTypes } from './common'
@@ -42,7 +44,9 @@ describe('finding records', () => {
 
     // TODO: Don't mock
     // TODO: Should ID (not raw) response be tested?
-    adapter.find = jest.fn().mockReturnValueOnce({ id: 'm1' })
+    adapter.find = jest
+      .fn()
+      .mockImplementation((table, id, callback) => callback({ value: { id: 'm1' } }))
 
     // calls db
     const m1 = await collection.find('m1')
@@ -54,7 +58,7 @@ describe('finding records', () => {
     expect(collection._cache.map.size).toBe(1)
 
     // check call
-    expect(adapter.find.mock.calls[0]).toEqual(['mock_tasks', 'm1'])
+    expect(adapter.find.mock.calls[0]).toEqual(['mock_tasks', 'm1', expect.anything()])
 
     // second find will be from cache
     const m1Cached = await collection.find('m1')
@@ -65,13 +69,12 @@ describe('finding records', () => {
   })
   it('rejects promise if record cannot be found', async () => {
     const { tasks: collection, adapter } = mockDatabase()
-
-    adapter.find = jest.fn().mockReturnValue(null)
+    const findSpy = jest.spyOn(adapter, 'find')
 
     await expect(collection.find('m1')).rejects.toBeInstanceOf(Error)
     await expect(collection.find('m1')).rejects.toBeInstanceOf(Error)
 
-    expect(adapter.find.mock.calls.length).toBe(2)
+    expect(findSpy.mock.calls.length).toBe(2)
   })
 })
 
@@ -79,12 +82,14 @@ describe('fetching queries', () => {
   it('fetches queries and caches records', async () => {
     const { tasks: collection, adapter } = mockDatabase()
 
-    adapter.query = jest.fn().mockReturnValueOnce([{ id: 'm1' }, { id: 'm2' }])
+    adapter.query = jest
+      .fn()
+      .mockImplementation((query, cb) => cb({ value: [{ id: 'm1' }, { id: 'm2' }] }))
 
     const query = mockQuery(collection)
 
     // fetch, check models
-    const models = await collection.fetchQuery(query)
+    const models = await toPromise(callback => collection._fetchQuery(query, callback))
     expect(models.length).toBe(2)
 
     expect(models[0]._raw).toEqual({ id: 'm1' })
@@ -104,13 +109,13 @@ describe('fetching queries', () => {
   it('fetches query records from cache if possible', async () => {
     const { tasks: collection, adapter } = mockDatabase()
 
-    adapter.query = jest.fn().mockReturnValueOnce(['m1', { id: 'm2' }])
+    adapter.query = jest.fn().mockImplementation((query, cb) => cb({ value: ['m1', { id: 'm2' }] }))
 
     const m1 = new MockTask(collection, { id: 'm1' })
     collection._cache.add(m1)
 
     // fetch, check models
-    const models = await collection.fetchQuery(mockQuery(collection))
+    const models = await toPromise(cb => collection._fetchQuery(mockQuery(collection), cb))
     expect(models.length).toBe(2)
     expect(models[0]).toBe(m1)
     expect(models[1]._raw).toEqual({ id: 'm2' })
@@ -121,14 +126,16 @@ describe('fetching queries', () => {
   it('fetches query records from cache even if full raw object was sent', async () => {
     const { tasks: collection, adapter } = mockDatabase()
 
-    adapter.query = jest.fn().mockReturnValueOnce([{ id: 'm1' }, { id: 'm2' }])
+    adapter.query = jest
+      .fn()
+      .mockImplementation((query, cb) => cb({ value: [{ id: 'm1' }, { id: 'm2' }] }))
 
     const m1 = new MockTask(collection, { id: 'm1' })
     collection._cache.add(m1)
 
     // fetch, check if error occured
     const spy = jest.spyOn(logger, 'error').mockImplementation(() => {})
-    const models = await collection.fetchQuery(mockQuery(collection))
+    const models = await toPromise(cb => collection._fetchQuery(mockQuery(collection), cb))
     expect(spy).toHaveBeenCalledTimes(1)
     spy.mockRestore()
 
@@ -142,13 +149,13 @@ describe('fetching queries', () => {
 
     adapter.count = jest
       .fn()
-      .mockReturnValueOnce(5)
-      .mockReturnValueOnce(10)
+      .mockImplementationOnce((query, callback) => callback({ value: 5 }))
+      .mockImplementationOnce((query, callback) => callback({ value: 10 }))
 
     const query = mockQuery(collection)
 
-    expect(await collection.fetchCount(query)).toBe(5)
-    expect(await collection.fetchCount(query)).toBe(10)
+    expect(await toPromise(callback => collection._fetchCount(query, callback))).toBe(5)
+    expect(await toPromise(callback => collection._fetchCount(query, callback))).toBe(10)
 
     expect(adapter.count.mock.calls.length).toBe(2)
     expect(adapter.count.mock.calls[0][0]).toEqual(query.serialize())
@@ -173,7 +180,7 @@ describe('creating new records', () => {
     expect(m1._isCommitted).toBe(true)
     expect(newModelSpy).toHaveBeenCalledTimes(1)
     expect(dbBatchSpy).toHaveBeenCalledTimes(1)
-    expect(dbBatchSpy).toHaveBeenCalledWith([['create', 'mock_tasks', m1._raw]])
+    expect(dbBatchSpy).toHaveBeenCalledWith([['create', 'mock_tasks', m1._raw]], expect.anything())
     expect(observer).toHaveBeenCalledTimes(1)
     expect(observer).toHaveBeenCalledWith([{ record: m1, type: CollectionChangeTypes.created }])
     expect(collection._cache.get(m1.id)).toBe(m1)

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -10,6 +10,7 @@ import { invariant } from '../utils/common'
 import { noop } from '../utils/fp'
 
 import type { DatabaseAdapter, BatchOperation } from '../adapters/type'
+import DatabaseAdapterCompat from '../adapters/compat'
 import type Model from '../Model'
 import { type CollectionChangeSet } from '../Collection'
 import { CollectionChangeTypes } from '../Collection/common'
@@ -25,7 +26,7 @@ type DatabaseProps = $Exact<{
 }>
 
 export default class Database {
-  adapter: DatabaseAdapter
+  adapter: DatabaseAdapterCompat
 
   schema: AppSchema
 
@@ -47,7 +48,7 @@ export default class Database {
         'You must pass `actionsEnabled:` key to Database constructor. It is highly recommended you pass `actionsEnabled: true` (see documentation for more details), but can pass `actionsEnabled: false` for backwards compatibility.',
       )
     }
-    this.adapter = adapter
+    this.adapter = new DatabaseAdapterCompat(adapter)
     this.schema = adapter.schema
     this.collections = new CollectionMap(this, modelClasses)
     this._actionsEnabled = actionsEnabled

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -106,16 +106,18 @@ export default class Database {
 
     await this.adapter.batch(batchOperations)
 
+    // NOTE: Collections must be notified first to ensure that batched
+    // elements are marked as cached
+    Object.entries(changeNotifications).forEach(notification => {
+      const [table, changeSet]: [TableName<any>, CollectionChangeSet<any>] = (notification: any)
+      this.collections.get(table).changeSet(changeSet)
+    })
+
     const affectedTables = Object.keys(changeNotifications)
     this._subscribers.forEach(([tables, subscriber]) => {
       if (tables.some(table => affectedTables.includes(table))) {
         subscriber()
       }
-    })
-
-    Object.entries(changeNotifications).forEach(notification => {
-      const [table, changeSet]: [TableName<any>, CollectionChangeSet<any>] = (notification: any)
-      this.collections.get(table).changeSet(changeSet)
     })
   }
 

--- a/src/Query/index.js
+++ b/src/Query/index.js
@@ -70,7 +70,7 @@ export default class Query<Record: Model> {
 
   // Queries database and returns an array of matching records
   fetch(): Promise<Record[]> {
-    return this.collection.fetchQuery(this)
+    return this.collection._fetchQuery(this)
   }
 
   // Emits an array of matching records, then emits a new array every time it changes
@@ -94,7 +94,7 @@ export default class Query<Record: Model> {
 
   // Returns the number of matching records
   fetchCount(): Promise<number> {
-    return this.collection.fetchCount(this)
+    return this.collection._fetchCount(this)
   }
 
   // Emits the number of matching records, then emits a new count every time it changes

--- a/src/Query/index.js
+++ b/src/Query/index.js
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs/Observable'
 import { prepend } from 'rambdax'
 
 import allPromises from '../utils/fp/allPromises'
+import { toPromise } from '../utils/fp/Result'
 import { type Unsubscribe, SharedSubscribable } from '../utils/subscriptions'
 
 // TODO: ?
@@ -70,7 +71,7 @@ export default class Query<Record: Model> {
 
   // Queries database and returns an array of matching records
   fetch(): Promise<Record[]> {
-    return this.collection._fetchQuery(this)
+    return toPromise(callback => this.collection._fetchQuery(this, callback))
   }
 
   // Emits an array of matching records, then emits a new array every time it changes
@@ -94,7 +95,7 @@ export default class Query<Record: Model> {
 
   // Returns the number of matching records
   fetchCount(): Promise<number> {
-    return this.collection._fetchCount(this)
+    return toPromise(callback => this.collection._fetchCount(this, callback))
   }
 
   // Emits the number of matching records, then emits a new count every time it changes

--- a/src/Query/test.js
+++ b/src/Query/test.js
@@ -134,7 +134,7 @@ describe('Query observation', () => {
   }
   const testQueryObservation = async (makeSubscribe, withColumns) => {
     const { database, tasks } = mockDatabase({ actionsEnabled: true })
-    const adapterSpy = jest.spyOn(database.adapter, 'query')
+    const adapterSpy = jest.spyOn(database.adapter.underlyingAdapter, 'query')
     const query = new Query(tasks, [])
     const observer = jest.fn()
 
@@ -187,7 +187,7 @@ describe('Query observation', () => {
 
   const testCountObservation = async (makeSubscribe, isThrottled) => {
     const { database, tasks } = mockDatabase({ actionsEnabled: true })
-    const adapterSpy = jest.spyOn(database.adapter, 'count')
+    const adapterSpy = jest.spyOn(database.adapter.underlyingAdapter, 'count')
     const query = new Query(tasks, [])
     const observer = jest.fn()
 

--- a/src/__tests__/testModels.js
+++ b/src/__tests__/testModels.js
@@ -107,7 +107,7 @@ export const mockDatabase = ({ actionsEnabled = false } = {}) => {
     cloneDatabase: () =>
       // simulate reload
       new Database({
-        adapter: database.adapter.testClone(),
+        adapter: database.adapter.underlyingAdapter.testClone(),
         schema: testSchema,
         modelClasses: [MockProject, MockTask, MockComment],
         actionsEnabled,

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -8,6 +8,7 @@ import { appSchema, tableSchema } from '../../Schema'
 import { schemaMigrations, createTable, addColumns } from '../../Schema/migrations'
 
 import { matchTests, joinTests } from '../../__tests__/databaseTests'
+import DatabaseAdapterCompat from '../compat'
 import {
   testSchema,
   taskQuery,
@@ -632,10 +633,12 @@ export default () => [
         ],
       })
 
-      let adapter = new AdapterClass({
-        schema: testSchemaV3,
-        migrations: schemaMigrations({ migrations: [{ toVersion: 3, steps: [] }] }),
-      })
+      let adapter = new DatabaseAdapterCompat(
+        new AdapterClass({
+          schema: testSchemaV3,
+          migrations: schemaMigrations({ migrations: [{ toVersion: 3, steps: [] }] }),
+        }),
+      )
 
       // add data
       await adapter.batch([
@@ -754,10 +757,12 @@ export default () => [
   [
     `can perform empty migrations (regression test)`,
     async (_adapter, AdapterClass) => {
-      let adapter = new AdapterClass({
-        schema: { ...testSchema, version: 1 },
-        migrations: schemaMigrations({ migrations: [] }),
-      })
+      let adapter = new DatabaseAdapterCompat(
+        new AdapterClass({
+          schema: { ...testSchema, version: 1 },
+          migrations: schemaMigrations({ migrations: [] }),
+        }),
+      )
 
       await adapter.batch([['create', 'tasks', mockTaskRaw({ id: 't1', text1: 'foo' })]])
       expect(await adapter.count(taskQuery())).toBe(1)
@@ -777,10 +782,12 @@ export default () => [
     `resets database when it's newer than app schema`,
     async (_adapter, AdapterClass) => {
       // launch newer version of the app
-      let adapter = new AdapterClass({
-        schema: { ...testSchema, version: 3 },
-        migrations: schemaMigrations({ migrations: [{ toVersion: 3, steps: [] }] }),
-      })
+      let adapter = new DatabaseAdapterCompat(
+        new AdapterClass({
+          schema: { ...testSchema, version: 3 },
+          migrations: schemaMigrations({ migrations: [{ toVersion: 3, steps: [] }] }),
+        }),
+      )
 
       await adapter.batch([['create', 'tasks', mockTaskRaw({})]])
       expect(await adapter.count(taskQuery())).toBe(1)
@@ -800,10 +807,12 @@ export default () => [
     'resets database when there are no available migrations',
     async (_adapter, AdapterClass) => {
       // launch older version of the app
-      let adapter = new AdapterClass({
-        schema: { ...testSchema, version: 1 },
-        migrations: schemaMigrations({ migrations: [] }),
-      })
+      let adapter = new DatabaseAdapterCompat(
+        new AdapterClass({
+          schema: { ...testSchema, version: 1 },
+          migrations: schemaMigrations({ migrations: [] }),
+        }),
+      )
 
       await adapter.batch([['create', 'tasks', mockTaskRaw({})]])
       expect(await adapter.count(taskQuery())).toBe(1)
@@ -823,10 +832,12 @@ export default () => [
     'errors when migration fails',
     async (_adapter, AdapterClass) => {
       // launch older version of the app
-      let adapter = new AdapterClass({
-        schema: { ...testSchema, version: 1 },
-        migrations: schemaMigrations({ migrations: [] }),
-      })
+      let adapter = new DatabaseAdapterCompat(
+        new AdapterClass({
+          schema: { ...testSchema, version: 1 },
+          migrations: schemaMigrations({ migrations: [] }),
+        }),
+      )
 
       await adapter.batch([['create', 'tasks', mockTaskRaw({})]])
       expect(await adapter.count(taskQuery())).toBe(1)

--- a/src/adapters/common.js
+++ b/src/adapters/common.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { logger, invariant } from '../utils/common'
+import { type Result } from '../utils/fp/Result'
 import type { RecordId } from '../Model'
 import type { TableSchema } from '../Schema'
 import type { CachedQueryResult, CachedFindResult, DatabaseAdapter } from './type'
@@ -53,13 +54,11 @@ export function sanitizeQueryResult(
   )
 }
 
-export async function devLogSetUp<T>(executeBlock: () => Promise<T>): Promise<void> {
-  try {
-    executeBlock()
-  } catch (error) {
+export function devSetupCallback(result: Result<any>): void {
+  if (result.error) {
     logger.error(
       `[DB] Uh-oh. Database failed to load, we're in big trouble. This might happen if you didn't set up native code correctly (iOS, Android), or if you didn't recompile native app after WatermelonDB update. It might also mean that IndexedDB or SQLite refused to open.`,
-      error,
+      result.error,
     )
   }
 }

--- a/src/adapters/compat.js
+++ b/src/adapters/compat.js
@@ -1,0 +1,87 @@
+// @flow
+
+import type { SerializedQuery } from '../Query'
+import type { TableName, AppSchema } from '../Schema'
+import type { SchemaMigrations } from '../Schema/migrations'
+import type { RecordId } from '../Model'
+import { toPromise } from '../utils/fp/Result'
+
+import type {
+  DatabaseAdapter,
+  CachedFindResult,
+  CachedQueryResult,
+  BatchOperation,
+  SQLDatabaseAdapter,
+} from './type'
+
+export default class DatabaseAdapterCompat {
+  underlyingAdapter: DatabaseAdapter
+
+  constructor(adapter: DatabaseAdapter): void {
+    this.underlyingAdapter = adapter
+
+    const sqlAdapter: SQLDatabaseAdapter = (adapter: any)
+    if (sqlAdapter.unsafeSqlQuery) {
+      this.unsafeSqlQuery = (tableName, sql) =>
+        toPromise(callback => sqlAdapter.unsafeSqlQuery(tableName, sql, callback))
+    }
+  }
+
+  get schema(): AppSchema {
+    return this.underlyingAdapter.schema
+  }
+
+  get migrations(): ?SchemaMigrations {
+    return this.underlyingAdapter.migrations
+  }
+
+  find(table: TableName<any>, id: RecordId): Promise<CachedFindResult> {
+    return toPromise(callback => this.underlyingAdapter.find(table, id, callback))
+  }
+
+  query(query: SerializedQuery): Promise<CachedQueryResult> {
+    return toPromise(callback => this.underlyingAdapter.query(query, callback))
+  }
+
+  count(query: SerializedQuery): Promise<number> {
+    return toPromise(callback => this.underlyingAdapter.count(query, callback))
+  }
+
+  batch(operations: BatchOperation[]): Promise<void> {
+    return toPromise(callback => this.underlyingAdapter.batch(operations, callback))
+  }
+
+  getDeletedRecords(tableName: TableName<any>): Promise<RecordId[]> {
+    return toPromise(callback => this.underlyingAdapter.getDeletedRecords(tableName, callback))
+  }
+
+  destroyDeletedRecords(tableName: TableName<any>, recordIds: RecordId[]): Promise<void> {
+    return toPromise(callback =>
+      this.underlyingAdapter.destroyDeletedRecords(tableName, recordIds, callback),
+    )
+  }
+
+  unsafeResetDatabase(): Promise<void> {
+    return toPromise(callback => this.underlyingAdapter.unsafeResetDatabase(callback))
+  }
+
+  getLocal(key: string): Promise<?string> {
+    return toPromise(callback => this.underlyingAdapter.getLocal(key, callback))
+  }
+
+  setLocal(key: string, value: string): Promise<void> {
+    return toPromise(callback => this.underlyingAdapter.setLocal(key, value, callback))
+  }
+
+  removeLocal(key: string): Promise<void> {
+    return toPromise(callback => this.underlyingAdapter.removeLocal(key, callback))
+  }
+
+  unsafeSqlQuery: ?(tableName: TableName<any>, sql: string) => Promise<CachedQueryResult>
+
+  // untyped - test-only code
+  testClone(options: any): any {
+    // $FlowFixMe
+    return new DatabaseAdapterCompat(this.underlyingAdapter.testClone(options))
+  }
+}

--- a/src/adapters/lokijs/WorkerBridge.js
+++ b/src/adapters/lokijs/WorkerBridge.js
@@ -48,6 +48,7 @@ class WorkerBridge {
       // sanity check
       if (id !== responseId) {
         callback({ error: (new Error('Loki worker responses are out of order'): any) })
+        return
       }
 
       if (type === RESPONSE_ERROR) {

--- a/src/adapters/lokijs/WorkerBridge.js
+++ b/src/adapters/lokijs/WorkerBridge.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { Result } from '../../utils/fp/Result'
+import type { ResultCallback } from '../../utils/fp/Result'
 import {
   responseActions,
   type WorkerExecutorType,
@@ -11,7 +11,7 @@ import {
 
 type WorkerAction = {
   id: number,
-  callback: (Result<WorkerResponsePayload>) => void,
+  callback: ResultCallback<WorkerResponsePayload>,
 }
 type WorkerActions = WorkerAction[]
 
@@ -63,7 +63,7 @@ class WorkerBridge {
   send<T>(
     type: WorkerExecutorType,
     payload: WorkerExecutorPayload = [],
-    callback: (Result<T>) => void,
+    callback: ResultCallback<T>,
     cloneMethod: 'shallowCloneDeepObjects' | 'immutable' | 'deep' = 'deep',
   ): void {
     const id = nextActionId()

--- a/src/adapters/lokijs/common.js
+++ b/src/adapters/lokijs/common.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { type Result } from '../../utils/fp/Result'
 import type { CachedQueryResult, CachedFindResult } from '../type'
 import type { RecordId } from '../../Model'
 
@@ -17,19 +18,10 @@ export const actions = {
   REMOVE_LOCAL: 'REMOVE_LOCAL',
 }
 
-export const responseActions = {
-  RESPONSE_SUCCESS: 'RESPONSE_SUCCESS',
-  RESPONSE_ERROR: 'RESPONSE_ERROR',
-}
-
 export type WorkerExecutorType = $Values<typeof actions>
 export type WorkerExecutorPayload = any[]
 
-export type WorkerResponseType = $Values<typeof responseActions>
-
 export type WorkerResponseData = CachedQueryResult | CachedFindResult | number | RecordId[]
-export type WorkerResponseError = string
-export type WorkerResponsePayload = WorkerResponseData | WorkerResponseError
 
 export type WorkerAction = $Exact<{
   id: number,
@@ -39,6 +31,5 @@ export type WorkerAction = $Exact<{
 
 export type WorkerResponse = $Exact<{
   id: number,
-  type: WorkerResponseType,
-  payload: WorkerResponsePayload,
+  result: Result<WorkerResponseData>,
 }>

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -2,7 +2,7 @@
 
 import type { LokiMemoryAdapter } from 'lokijs'
 import { invariant } from '../../utils/common'
-import type { Result } from '../../utils/fp/Result'
+import type { ResultCallback } from '../../utils/fp/Result'
 
 import type { RecordId } from '../../Model'
 import type { TableName, AppSchema } from '../../Schema'
@@ -93,50 +93,50 @@ export default class LokiJSAdapter implements DatabaseAdapter {
     })
   }
 
-  find(table: TableName<any>, id: RecordId, callback: (Result<CachedFindResult>) => void): void {
+  find(table: TableName<any>, id: RecordId, callback: ResultCallback<CachedFindResult>): void {
     this.workerBridge.send(FIND, [table, id], callback)
   }
 
-  query(query: SerializedQuery, callback: (Result<CachedQueryResult>) => void): void {
+  query(query: SerializedQuery, callback: ResultCallback<CachedQueryResult>): void {
     // SerializedQueries are immutable, so we need no copy
     this.workerBridge.send(QUERY, [query], callback, 'immutable')
   }
 
-  count(query: SerializedQuery, callback: (Result<number>) => void): void {
+  count(query: SerializedQuery, callback: ResultCallback<number>): void {
     // SerializedQueries are immutable, so we need no copy
     this.workerBridge.send(COUNT, [query], callback, 'immutable')
   }
 
-  batch(operations: BatchOperation[], callback: (Result<void>) => void): void {
+  batch(operations: BatchOperation[], callback: ResultCallback<void>): void {
     // batches are only strings + raws which only have JSON-compatible values, rest is immutable
     this.workerBridge.send(BATCH, [operations], callback, 'shallowCloneDeepObjects')
   }
 
-  getDeletedRecords(tableName: TableName<any>, callback: (Result<RecordId[]>) => void): void {
+  getDeletedRecords(tableName: TableName<any>, callback: ResultCallback<RecordId[]>): void {
     this.workerBridge.send(GET_DELETED_RECORDS, [tableName], callback)
   }
 
   destroyDeletedRecords(
     tableName: TableName<any>,
     recordIds: RecordId[],
-    callback: (Result<void>) => void,
+    callback: ResultCallback<void>,
   ): void {
     this.workerBridge.send(DESTROY_DELETED_RECORDS, [tableName, recordIds], callback)
   }
 
-  unsafeResetDatabase(callback: (Result<void>) => void): void {
+  unsafeResetDatabase(callback: ResultCallback<void>): void {
     this.workerBridge.send(UNSAFE_RESET_DATABASE, [], callback)
   }
 
-  getLocal(key: string, callback: (Result<?string>) => void): void {
+  getLocal(key: string, callback: ResultCallback<?string>): void {
     this.workerBridge.send(GET_LOCAL, [key], callback)
   }
 
-  setLocal(key: string, value: string, callback: (Result<void>) => void): void {
+  setLocal(key: string, value: string, callback: ResultCallback<void>): void {
     this.workerBridge.send(SET_LOCAL, [key, value], callback)
   }
 
-  removeLocal(key: string, callback: (Result<void>) => void): void {
+  removeLocal(key: string, callback: ResultCallback<void>): void {
     this.workerBridge.send(REMOVE_LOCAL, [key], callback)
   }
 }

--- a/src/adapters/lokijs/test.js
+++ b/src/adapters/lokijs/test.js
@@ -2,6 +2,7 @@ import { testSchema } from '../__tests__/helpers'
 import commonTests from '../__tests__/commonTests'
 
 import LokiJSAdapter from './index'
+import DatabaseAdapterCompat from '../compat'
 
 // require('fake-indexeddb/auto')
 
@@ -15,7 +16,7 @@ describe('LokiJSAdapter (Synchronous / Memory persistence)', () => {
         schema: testSchema,
         useWebWorker: false,
       })
-      await test(adapter, LokiJSAdapter)
+      await test(new DatabaseAdapterCompat(adapter), LokiJSAdapter)
     })
   })
 })

--- a/src/adapters/lokijs/worker/lokiWorker.js
+++ b/src/adapters/lokijs/worker/lokiWorker.js
@@ -52,7 +52,7 @@ export default class LokiWorker {
   executeNext(): void {
     const action = this.queue[0]
     const onActionDone = (response: WorkerResponse): void => {
-      invariant(this._actionsExecuting === 1, 'worker queue should have 1 item')
+      invariant(this._actionsExecuting === 1, 'worker should be executing 1 action')
       this._actionsExecuting = 0
       this.queue.shift()
 
@@ -63,7 +63,7 @@ export default class LokiWorker {
       }
     }
 
-    invariant(this._actionsExecuting === 0, 'worker queue should be empty') // sanity check
+    invariant(this._actionsExecuting === 0, 'worker should not have ongoing actions') // sanity check
     this.processAction(action, onActionDone)
   }
 

--- a/src/adapters/lokijs/worker/lokiWorker.js
+++ b/src/adapters/lokijs/worker/lokiWorker.js
@@ -51,28 +51,54 @@ export default class LokiWorker {
 
   executeNext(): void {
     const action = this.queue[0]
-    const onActionDone = (response: WorkerResponse): void => {
-      invariant(this._actionsExecuting === 1, 'worker should be executing 1 action')
-      this._actionsExecuting = 0
-      this.queue.shift()
-
-      this.workerContext.postMessage(response)
-
-      if (this.queue.length) {
-        this.executeNext()
-      }
-    }
-
     invariant(this._actionsExecuting === 0, 'worker should not have ongoing actions') // sanity check
-    this.processAction(action, onActionDone)
+    this.processAction(action)
   }
 
-  async processAction(action: WorkerAction, callback: WorkerResponse => void): Promise<void> {
+  onActionDone(response: WorkerResponse): void {
+    invariant(this._actionsExecuting === 1, 'worker should be executing 1 action') // sanity check
+    this._actionsExecuting = 0
+    this.queue.shift()
+
+    try {
+      this.workerContext.postMessage(response)
+    } catch (error) {
+      logError(error)
+    }
+
+    if (this.queue.length) {
+      this.executeNext()
+    }
+  }
+
+  processAction(action: WorkerAction): void {
     try {
       this._actionsExecuting += 1
 
       const { type, payload, id } = action
       invariant(type in actions, `Unknown worker action ${type}`)
+
+      if (type === actions.SETUP || type === actions.UNSAFE_RESET_DATABASE) {
+        this.processActionAsync(action)
+      } else {
+        // run action
+        invariant(this.executor, `Cannot run actions because executor is not set up`)
+
+        const runExecutorAction = executorMethods[type].bind(this.executor)
+        const response = runExecutorAction(...payload)
+
+        this.onActionDone({ id, type: RESPONSE_SUCCESS, payload: response })
+      }
+    } catch (error) {
+      // Main process only receives error message — this logError is to retain call stack
+      logError(error)
+      this.onActionDone({ id: action.id, type: RESPONSE_ERROR, payload: error })
+    }
+  }
+
+  async processActionAsync(action: WorkerAction): Promise<void> {
+    try {
+      const { type, payload, id } = action
 
       if (type === actions.SETUP) {
         // app just launched, set up executor with options sent
@@ -84,7 +110,7 @@ export default class LokiWorker {
         await executor.setUp()
         this.executor = executor
 
-        callback({ id, type: RESPONSE_SUCCESS, payload: null })
+        this.onActionDone({ id, type: RESPONSE_SUCCESS, payload: null })
       } else {
         // run action
         invariant(this.executor, `Cannot run actions because executor is not set up`)
@@ -92,12 +118,12 @@ export default class LokiWorker {
         const runExecutorAction = executorMethods[type].bind(this.executor)
         const response = await runExecutorAction(...payload)
 
-        callback({ id, type: RESPONSE_SUCCESS, payload: response })
+        this.onActionDone({ id, type: RESPONSE_SUCCESS, payload: response })
       }
     } catch (error) {
       // Main process only receives error message — this logError is to retain call stack
       logError(error)
-      callback({ id: action.id, type: RESPONSE_ERROR, payload: error })
+      this.onActionDone({ id: action.id, type: RESPONSE_ERROR, payload: error })
     }
   }
 }

--- a/src/adapters/lokijs/worker/workerMock.js
+++ b/src/adapters/lokijs/worker/workerMock.js
@@ -18,8 +18,7 @@ export function shallowCloneDeepObjects(value: any): any {
   return value
 }
 
-// Simulates the web worker API for test env (while really just passing messages asynchronously
-// on main thread)
+// Simulates the web worker API
 export default class LokiWorkerMock {
   _worker: LokiWorker
 

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -168,7 +168,7 @@ const makeDispatcher = (isSynchronous: boolean): NativeDispatcher => {
     const name = isSynchronous ? `${methodName}Synchronous` : methodName
 
     return [
-      name,
+      methodName,
       (...args) => {
         const callback = args[args.length - 1]
         const otherArgs = args.slice(0, -1)

--- a/src/adapters/sqlite/integrationTest.js
+++ b/src/adapters/sqlite/integrationTest.js
@@ -4,6 +4,7 @@ import SQLiteAdapter from './index'
 import { testSchema } from '../__tests__/helpers'
 import commonTests from '../__tests__/commonTests'
 import { invariant } from '../../utils/common'
+import DatabaseAdapterCompat from '../compat'
 
 const SQLiteAdapterTest = spec => {
   const runTests = isSynchronous => {
@@ -28,7 +29,7 @@ const SQLiteAdapterTest = spec => {
         } else {
           invariant(adapter._synchronous === false, 'this should be asynchronous')
         }
-        await test(adapter, SQLiteAdapter)
+        await test(new DatabaseAdapterCompat(adapter), SQLiteAdapter)
       })
     })
   }

--- a/src/adapters/type.js
+++ b/src/adapters/type.js
@@ -5,6 +5,7 @@ import type { TableName, AppSchema } from '../Schema'
 import type { SchemaMigrations } from '../Schema/migrations'
 import type { RecordId } from '../Model'
 import type { RawRecord } from '../RawRecord'
+import type { Result } from '../utils/fp/Result'
 
 export type CachedFindResult = RecordId | ?RawRecord
 export type CachedQueryResult = Array<RecordId | RawRecord>
@@ -21,36 +22,44 @@ export interface DatabaseAdapter {
   migrations: ?SchemaMigrations; // TODO: Not optional
 
   // Fetches given (one) record or null. Should not send raw object if already cached in JS
-  find(table: TableName<any>, id: RecordId): Promise<CachedFindResult>;
+  find(table: TableName<any>, id: RecordId, callback: (Result<CachedFindResult>) => void): void;
 
   // Fetches matching records. Should not send raw object if already cached in JS
-  query(query: SerializedQuery): Promise<CachedQueryResult>;
+  query(query: SerializedQuery, callback: (Result<CachedQueryResult>) => void): void;
 
   // Counts matching records
-  count(query: SerializedQuery): Promise<number>;
+  count(query: SerializedQuery, callback: (Result<number>) => void): void;
 
   // Executes multiple prepared operations
-  batch(operations: BatchOperation[]): Promise<void>;
+  batch(operations: BatchOperation[], callback: (Result<void>) => void): void;
 
   // Return marked as deleted records
-  getDeletedRecords(tableName: TableName<any>): Promise<RecordId[]>;
+  getDeletedRecords(tableName: TableName<any>, callback: (Result<RecordId[]>) => void): void;
 
   // Destroy deleted records from sync
-  destroyDeletedRecords(tableName: TableName<any>, recordIds: RecordId[]): Promise<void>;
+  destroyDeletedRecords(
+    tableName: TableName<any>,
+    recordIds: RecordId[],
+    callback: (Result<void>) => void,
+  ): void;
 
   // Destroys the whole database, its schema, indexes, everything.
-  unsafeResetDatabase(): Promise<void>;
+  unsafeResetDatabase(callback: (Result<void>) => void): void;
 
   // Fetches string value from local storage
-  getLocal(key: string): Promise<?string>;
+  getLocal(key: string, callback: (Result<?string>) => void): void;
 
   // Sets string value to a local storage key
-  setLocal(key: string, value: string): Promise<void>;
+  setLocal(key: string, value: string, callback: (Result<void>) => void): void;
 
   // Removes key from local storage
-  removeLocal(key: string): Promise<void>;
+  removeLocal(key: string, callback: (Result<void>) => void): void;
 }
 
 export interface SQLDatabaseAdapter {
-  unsafeSqlQuery(tableName: TableName<any>, sql: string): Promise<CachedQueryResult>;
+  unsafeSqlQuery(
+    tableName: TableName<any>,
+    sql: string,
+    callback: (Result<CachedQueryResult>) => void,
+  ): void;
 }

--- a/src/adapters/type.js
+++ b/src/adapters/type.js
@@ -5,7 +5,7 @@ import type { TableName, AppSchema } from '../Schema'
 import type { SchemaMigrations } from '../Schema/migrations'
 import type { RecordId } from '../Model'
 import type { RawRecord } from '../RawRecord'
-import type { Result } from '../utils/fp/Result'
+import type { ResultCallback } from '../utils/fp/Result'
 
 export type CachedFindResult = RecordId | ?RawRecord
 export type CachedQueryResult = Array<RecordId | RawRecord>
@@ -22,44 +22,44 @@ export interface DatabaseAdapter {
   migrations: ?SchemaMigrations; // TODO: Not optional
 
   // Fetches given (one) record or null. Should not send raw object if already cached in JS
-  find(table: TableName<any>, id: RecordId, callback: (Result<CachedFindResult>) => void): void;
+  find(table: TableName<any>, id: RecordId, callback: ResultCallback<CachedFindResult>): void;
 
   // Fetches matching records. Should not send raw object if already cached in JS
-  query(query: SerializedQuery, callback: (Result<CachedQueryResult>) => void): void;
+  query(query: SerializedQuery, callback: ResultCallback<CachedQueryResult>): void;
 
   // Counts matching records
-  count(query: SerializedQuery, callback: (Result<number>) => void): void;
+  count(query: SerializedQuery, callback: ResultCallback<number>): void;
 
   // Executes multiple prepared operations
-  batch(operations: BatchOperation[], callback: (Result<void>) => void): void;
+  batch(operations: BatchOperation[], callback: ResultCallback<void>): void;
 
   // Return marked as deleted records
-  getDeletedRecords(tableName: TableName<any>, callback: (Result<RecordId[]>) => void): void;
+  getDeletedRecords(tableName: TableName<any>, callback: ResultCallback<RecordId[]>): void;
 
   // Destroy deleted records from sync
   destroyDeletedRecords(
     tableName: TableName<any>,
     recordIds: RecordId[],
-    callback: (Result<void>) => void,
+    callback: ResultCallback<void>,
   ): void;
 
   // Destroys the whole database, its schema, indexes, everything.
-  unsafeResetDatabase(callback: (Result<void>) => void): void;
+  unsafeResetDatabase(callback: ResultCallback<void>): void;
 
   // Fetches string value from local storage
-  getLocal(key: string, callback: (Result<?string>) => void): void;
+  getLocal(key: string, callback: ResultCallback<?string>): void;
 
   // Sets string value to a local storage key
-  setLocal(key: string, value: string, callback: (Result<void>) => void): void;
+  setLocal(key: string, value: string, callback: ResultCallback<void>): void;
 
   // Removes key from local storage
-  removeLocal(key: string, callback: (Result<void>) => void): void;
+  removeLocal(key: string, callback: ResultCallback<void>): void;
 }
 
 export interface SQLDatabaseAdapter {
   unsafeSqlQuery(
     tableName: TableName<any>,
     sql: string,
-    callback: (Result<CachedQueryResult>) => void,
+    callback: ResultCallback<CachedQueryResult>,
   ): void;
 }

--- a/src/observation/subscribeToCount/index.js
+++ b/src/observation/subscribeToCount/index.js
@@ -45,7 +45,7 @@ export default function subscribeToCount<Record: Model>(
 
   let previousCount = -1
   const observeCountFetch = () => {
-    collection.fetchCount(query).then(count => {
+    collection._fetchCount(query).then(count => {
       const shouldEmit = count !== previousCount && !unsubscribed
       previousCount = count
       shouldEmit && subscriber(count)

--- a/src/observation/subscribeToCount/index.js
+++ b/src/observation/subscribeToCount/index.js
@@ -3,6 +3,8 @@
 import { Observable } from 'rxjs/Observable'
 import { switchMap, distinctUntilChanged, throttleTime } from 'rxjs/operators'
 
+import { logError } from '../../utils/common'
+import { toPromise } from '../../utils/fp/Result'
 import { type Unsubscribe } from '../../utils/subscriptions'
 
 import type Query from '../../Query'
@@ -24,7 +26,7 @@ function observeCountThrottled<Record: Model>(query: Query<Record>): Observable<
   const { collection } = query
   return collection.database.withChangesForTables(query.allTables).pipe(
     throttleTime(250), // Note: this has a bug, but we'll delete it anyway
-    switchMap(() => collection.fetchCount(query)),
+    switchMap(() => toPromise(callback => collection._fetchCount(query, callback))),
     distinctUntilChanged(),
   )
 }
@@ -45,7 +47,13 @@ export default function subscribeToCount<Record: Model>(
 
   let previousCount = -1
   const observeCountFetch = () => {
-    collection._fetchCount(query).then(count => {
+    collection._fetchCount(query, result => {
+      if (result.error) {
+        logError(result.error.toString())
+        return
+      }
+
+      const count = result.value
       const shouldEmit = count !== previousCount && !unsubscribed
       previousCount = count
       shouldEmit && subscriber(count)

--- a/src/observation/subscribeToQueryReloading/index.js
+++ b/src/observation/subscribeToQueryReloading/index.js
@@ -42,10 +42,9 @@ export default function subscribeToQueryReloading<Record: Model>(
     })
   }
 
-  const unsubscribe = collection.database.experimentalSubscribe(
-    query.allTables,
-    reloadingObserverFetch,
-  )
+  const unsubscribe = collection.database.experimentalSubscribe(query.allTables, () => {
+    reloadingObserverFetch()
+  })
   reloadingObserverFetch()
 
   return () => {

--- a/src/observation/subscribeToQueryReloading/index.js
+++ b/src/observation/subscribeToQueryReloading/index.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { logError } from '../../utils/common'
 import identicalArrays from '../../utils/fp/identicalArrays'
 import { type Unsubscribe } from '../../utils/subscriptions'
 
@@ -26,7 +27,13 @@ export default function subscribeToQueryReloading<Record: Model>(
       subscriber((false: any))
     }
 
-    collection.fetchQuery(query).then(records => {
+    collection._fetchQuery(query, result => {
+      if (!result.value) {
+        logError(result.error.toString())
+        return
+      }
+
+      const records = result.value
       const shouldEmit =
         !unsubscribed &&
         (shouldEmitStatus || !previousRecords || !identicalArrays(records, previousRecords))

--- a/src/observation/subscribeToQueryReloading/index.js
+++ b/src/observation/subscribeToQueryReloading/index.js
@@ -42,9 +42,10 @@ export default function subscribeToQueryReloading<Record: Model>(
     })
   }
 
-  const unsubscribe = collection.database.experimentalSubscribe(query.allTables, () => {
-    reloadingObserverFetch()
-  })
+  const unsubscribe = collection.database.experimentalSubscribe(
+    query.allTables,
+    reloadingObserverFetch,
+  )
   reloadingObserverFetch()
 
   return () => {

--- a/src/observation/subscribeToSimpleQuery/test.js
+++ b/src/observation/subscribeToSimpleQuery/test.js
@@ -5,17 +5,6 @@ import * as Q from '../../QueryDescription'
 
 import subscribeToSimpleQuery from './index'
 
-const makeDatabase = () => {
-  // TODO: Change test to actually go through the DB
-  const { database } = mockDatabase()
-
-  database.adapter = {
-    batch: jest.fn(),
-  }
-
-  return database
-}
-
 const makeMock = (database, name) =>
   database.collections.get('mock_tasks').create(mock => {
     mock.name = name
@@ -23,14 +12,11 @@ const makeMock = (database, name) =>
 
 describe('subscribeToSimpleQuery', () => {
   it('observes changes correctly', async () => {
-    const database = makeDatabase()
+    const { database } = mockDatabase()
 
     // insert a few models
     const m1 = await makeMock(database, 'bad_name')
     const m2 = await makeMock(database, 'foo')
-
-    // mock query
-    database.adapter.query = jest.fn().mockImplementationOnce(() => [m2.id])
 
     // start observing
     const query = new Query(database.collections.get('mock_tasks'), [Q.where('name', 'foo')])

--- a/src/sync/test.js
+++ b/src/sync/test.js
@@ -299,7 +299,7 @@ describe('markLocalChangesAsSynced', () => {
     expect(localChanges1).toEqual(localChanges2)
   })
   it('marks local changes as synced', async () => {
-    const { database, adapter, projects, tasks } = makeDatabase()
+    const { database, projects, tasks } = makeDatabase()
 
     await makeLocalChanges(database)
 
@@ -322,9 +322,9 @@ describe('markLocalChangesAsSynced', () => {
     expect(taskList.every(record => record.syncStatus === 'synced')).toBe(true)
 
     // no objects marked as deleted
-    expect(await adapter.getDeletedRecords('mock_projects')).toEqual([])
-    expect(await adapter.getDeletedRecords('mock_tasks')).toEqual([])
-    expect(await adapter.getDeletedRecords('mock_comments')).toEqual([])
+    expect(await database.adapter.getDeletedRecords('mock_projects')).toEqual([])
+    expect(await database.adapter.getDeletedRecords('mock_tasks')).toEqual([])
+    expect(await database.adapter.getDeletedRecords('mock_comments')).toEqual([])
   })
   it(`doesn't modify updated_at timestamps`, async () => {
     const { database, comments } = makeDatabase()

--- a/src/sync/test.js
+++ b/src/sync/test.js
@@ -668,7 +668,7 @@ describe('synchronize', () => {
       database,
       pullChanges: jest.fn(emptyPull()),
       // ensure we take more than 1ms for the log test
-      pushChanges: () => new Promise(resolve => setTimeout(resolve, 2)),
+      pushChanges: () => new Promise(resolve => setTimeout(resolve, 10)),
       log,
     })
 

--- a/src/utils/fp/Result/index.js
+++ b/src/utils/fp/Result/index.js
@@ -1,6 +1,8 @@
 // @flow
 
+// lightweight type-only Result (Success(T) | Error) monad
 export type Result<T> = $Exact<{ value: T }> | $Exact<{ error: Error }>
+
 export type ResultCallback<T> = (Result<T>) => void
 
 export function toPromise<T>(withCallback: (ResultCallback<T>) => void): Promise<T> {

--- a/src/utils/fp/Result/index.js
+++ b/src/utils/fp/Result/index.js
@@ -1,3 +1,16 @@
 // @flow
 
 export type Result<T> = $Exact<{ value: T }> | $Exact<{ error: Error }>
+export type ResultCallback<T> = (Result<T>) => void
+
+export function toPromise<T>(withCallback: (ResultCallback<T>) => void): Promise<T> {
+  return new Promise((resolve, reject) => {
+    withCallback(result => {
+      if (result.value) {
+        resolve(result.value)
+      } else if (result.error) {
+        reject(result.error)
+      }
+    })
+  })
+}

--- a/src/utils/fp/Result/index.js
+++ b/src/utils/fp/Result/index.js
@@ -6,11 +6,12 @@ export type ResultCallback<T> = (Result<T>) => void
 export function toPromise<T>(withCallback: (ResultCallback<T>) => void): Promise<T> {
   return new Promise((resolve, reject) => {
     withCallback(result => {
-      if (result.value) {
-        resolve(result.value)
-      } else if (result.error) {
+      if (result.error) {
         reject(result.error)
       }
+
+      // $FlowFixMe - yes, you do have a value
+      resolve(result.value)
     })
   })
 }

--- a/src/utils/fp/Result/index.js
+++ b/src/utils/fp/Result/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export type Result<T> = $Exact<{ value: T }> | $Exact<{ error: Error }>

--- a/src/utils/fp/Result/index.js
+++ b/src/utils/fp/Result/index.js
@@ -15,3 +15,19 @@ export function toPromise<T>(withCallback: (ResultCallback<T>) => void): Promise
     })
   })
 }
+
+export function fromPromise<T>(promise: Promise<T>, callback: ResultCallback<T>): void {
+  promise.then(value => callback({ value }), error => callback({ error }))
+}
+
+export function mapValue<T, U>(mapper: T => U, result: Result<T>): Result<U> {
+  if (result.error) {
+    return result
+  }
+
+  try {
+    return { value: mapper(result.value) }
+  } catch (error) {
+    return { error }
+  }
+}


### PR DESCRIPTION
So I implemented the Promise → callback switch in Adapters API to allow for bisynchronicity.

Pretty quickly I realized though that there's a ton of direct adapter calls, especially in test code, and it's going to be a huge pain in the ass to rewrite that all from async/await to dealing with callbacks.

The solution I came up with is I implemented `DatabaseAdapterCompat` which implements the OLD, unchanged Adapter interface. So using `database.adapter.xxxx(....)` requires no changes in code. When you want to use callback API for performance, you can go down to `database.adapter.underlyingAdapter.xxx(...)`.

It's not perfect… We add yet another layer of abstraction, and 🍉's complexity grows. There's also some side effects in test code where I need to drop down to underlyingAdapter or be careful about adapter handling when testCloning. But it makes the transition much easier overall, especially in light of the idea that while this is very profitable and worth pursuing now, we might decide in 6-12 months to revert many of those changes if React Suspense + async methods proves to be as performant.

I added some very lightweight `Result` monad types & operations.