### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
+- Fixed a possible cause for "Record ID xxx#yyy was sent over the bridge, but it's not cached" error
 - [LokiJS] Fixed an issue preventing database from saving when using `experimentalUseIncrementalIndexedDB`
 - Fixed a potential issue when using `database.unsafeResetDatabase()`
 - [iOS] Fixed issue with clearing database under experimental synchronous mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,10 @@ All notable changes to this project will be documented in this file.
   When enabled, database operations will block JavaScript thread. Adapter actions will resolve in the
   next microtask, which simplifies building flicker-free interfaces. Adapter will fall back to async
   operation when synchronous adapter is not available (e.g. when doing remote debugging)
-- [Model] Added experimental `model.experimentalSubscribe((isDeleted) => { ... })` method as a vanilla JS alternative to Rx based `model.observe()`. Unlike the latter, it does not notify the subscriber immediately upon subscription.
-- [Collection] Added internal `collection.experimentalSubscribe((changeSet) => { ... })` method as a vanilla JS alternative to Rx based `collection.changes` (you probably shouldn't be using this API anyway)
-- [Database] Added experimental `database.experimentalSubscribe(['table1', 'table2'], () => { ... })` method as a vanilla JS alternative to Rx-based `database.withChangesForTables()`. Unlike the latter, `experimentalSubscribe` notifies the subscriber only once after a batch that makes a change in multiple collections subscribed to. It also doesn't notify the subscriber immediately upon subscription, and doesn't send details about the changes, only a signal.
-- Added `experimentalDisableObserveCountThrottling()` to `@nozbe/watermelondb/observation/observeCount` that globally disables count observation throttling. We think that throttling on WatermelonDB level is not a good feature and will be removed in a future release - and will be better implemented on app level if necessary
-- [Query] Added experimental `query.experimentalSubscribe(records => { ... })`, `query.experimentalSubscribeWithColumns(['col1', 'col2'], records => { ... })`, and `query.experimentalSubscribeToCount(count => { ... })` methods
+- [LokiJS] Added new `onQuotaExceededError?: (error: Error) => void` option to `LokiJSAdapter` constructor.
+  This is called when underlying IndexedDB encountered a quota exceeded error (ran out of allotted disk space for app)
+  This means that app can't save more data or that it will fall back to using in-memory database only
+  Note that this only works when `useWebWorker: false`
 
 ### Changes
 
@@ -34,6 +33,14 @@ All notable changes to this project will be documented in this file.
 - [LokiJS] Fixed an issue preventing database from saving when using `experimentalUseIncrementalIndexedDB`
 - Fixed a potential issue when using `database.unsafeResetDatabase()`
 - [iOS] Fixed issue with clearing database under experimental synchronous mode
+
+### New features (Experimental)
+
+- [Model] Added experimental `model.experimentalSubscribe((isDeleted) => { ... })` method as a vanilla JS alternative to Rx based `model.observe()`. Unlike the latter, it does not notify the subscriber immediately upon subscription.
+- [Collection] Added internal `collection.experimentalSubscribe((changeSet) => { ... })` method as a vanilla JS alternative to Rx based `collection.changes` (you probably shouldn't be using this API anyway)
+- [Database] Added experimental `database.experimentalSubscribe(['table1', 'table2'], () => { ... })` method as a vanilla JS alternative to Rx-based `database.withChangesForTables()`. Unlike the latter, `experimentalSubscribe` notifies the subscriber only once after a batch that makes a change in multiple collections subscribed to. It also doesn't notify the subscriber immediately upon subscription, and doesn't send details about the changes, only a signal.
+- Added `experimentalDisableObserveCountThrottling()` to `@nozbe/watermelondb/observation/observeCount` that globally disables count observation throttling. We think that throttling on WatermelonDB level is not a good feature and will be removed in a future release - and will be better implemented on app level if necessary
+- [Query] Added experimental `query.experimentalSubscribe(records => { ... })`, `query.experimentalSubscribeWithColumns(['col1', 'col2'], records => { ... })`, and `query.experimentalSubscribeToCount(count => { ... })` methods
 
 ## 0.15 - 2019-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### ⚠️ Breaking
 
-(Low breakage risk)
+- `experimentalUseIncrementalIndexedDB` has been renamed to `useIncrementalIndexedDB`
+
+#### Low breakage risk
 
 - [adapters] Adapter API has changed from returning Promise to taking callbacks as the last argument. This won't affect you unless you call on adapter methods directly. `database.adapter` returns a new `DatabaseAdapterCompat` which has the same shape as old adapter API. You can use `database.adapter.underlyingAdapter` to get back `SQLiteAdapter` / `LokiJSAdapter`
 - [Collection] `Collection.fetchQuery` and `Collection.fetchCount` are removed. Please use `Query.fetch()` and `Query.fetchCount()`.

--- a/docs-master/Installation.md
+++ b/docs-master/Installation.md
@@ -246,7 +246,7 @@ const adapter = new LokiJSAdapter({
   schema,
   // These two options are recommended for new projects:
   useWebWorker: false,
-  experimentalUseIncrementalIndexedDB: true,
+  useIncrementalIndexedDB: true,
   // It's recommended you implement this method:
   // onIndexedDBVersionChange: () => {
   //   // database was deleted in another browser tab (user logged out), so we must make sure we delete

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nozbe/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "0.16.0-8",
+  "version": "0.16.0-9",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nozbe/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "0.16.0-7",
+  "version": "0.16.0-8",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/src/Collection/index.js
+++ b/src/Collection/index.js
@@ -137,7 +137,7 @@ export default class Collection<Record: Model> {
     )
   }
 
-  changeSet(operations: CollectionChangeSet<Record>): void {
+  _applyChangesToCache(operations: CollectionChangeSet<Record>): void {
     operations.forEach(({ record, type }) => {
       if (type === CollectionChangeTypes.created) {
         record._isCommitted = true
@@ -146,7 +146,9 @@ export default class Collection<Record: Model> {
         this._cache.delete(record)
       }
     })
+  }
 
+  _notify(operations: CollectionChangeSet<Record>): void {
     this._subscribers.forEach(subscriber => {
       subscriber(operations)
     })

--- a/src/Database/ActionQueue.js
+++ b/src/Database/ActionQueue.js
@@ -34,14 +34,14 @@ export default class ActionQueue implements ActionInterface {
         const queue = this._queue
         const current = queue[0]
         logger.warn(
-          `The action you're trying to perform (${description ||
+          `[WatermelonDB] The action you're trying to perform (${description ||
             'unnamed'}) can't be performed yet, because there are ${
             queue.length
           } actions in the queue. Current action: ${current.description ||
             'unnamed'}. Ignore this message if everything is working fine. But if your actions are not running, it's because the current action is stuck. Remember that if you're calling an action from an action, you must use subAction(). See docs for more details.`,
         )
-        logger.log(`Enqueued action:`, work)
-        logger.log(`Running action:`, current.work)
+        logger.log(`[WatermelonDB] Enqueued action:`, work)
+        logger.log(`[WatermelonDB] Running action:`, current.work)
       }
 
       this._queue.push({ work, resolve, reject, description })

--- a/src/Database/test.js
+++ b/src/Database/test.js
@@ -303,6 +303,33 @@ describe('Observation', () => {
     expect(subscriber1).toHaveBeenCalledTimes(1)
     unsubscribe1()
   })
+  it.only('has new objects cached before calling subscribers (regression test)', async () => {
+    const { database, projects, tasks } = mockDatabase({ actionsEnabled: true })
+
+    const project = projects.prepareCreate()
+    const task = tasks.prepareCreate(t => {
+      t.project.set(project)
+    })
+
+    let observerCalled = 0
+    let taskPromise = null
+    const observer = jest.fn(() => {
+      observerCalled += 1
+      if (observerCalled === 1) {
+        // nothing happens
+      } else {
+        taskPromise = projects.find(task.id)
+      }
+    })
+    database.withChangesForTables(['mock_projects']).subscribe(observer)
+    expect(observer).toHaveBeenCalledTimes(1)
+
+    await database.action(() => database.batch(project, task))
+    expect(observer).toHaveBeenCalledTimes(2)
+
+    // check if task is already cached
+    expect(await taskPromise).toBe(task)
+  })
 })
 
 const delayPromise = () => new Promise(resolve => setTimeout(resolve, 100))

--- a/src/Database/test.js
+++ b/src/Database/test.js
@@ -303,7 +303,7 @@ describe('Observation', () => {
     expect(subscriber1).toHaveBeenCalledTimes(1)
     unsubscribe1()
   })
-  it.only('has new objects cached before calling subscribers (regression test)', async () => {
+  it('has new objects cached before calling subscribers (regression test)', async () => {
     const { database, projects, tasks } = mockDatabase({ actionsEnabled: true })
 
     const project = projects.prepareCreate()
@@ -317,8 +317,8 @@ describe('Observation', () => {
       observerCalled += 1
       if (observerCalled === 1) {
         // nothing happens
-      } else {
-        taskPromise = projects.find(task.id)
+      } else if (observerCalled === 2) {
+        taskPromise = tasks.find(task.id)
       }
     })
     database.withChangesForTables(['mock_projects']).subscribe(observer)

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -37,7 +37,11 @@ export default () => [
       // expect(() => makeAdapter({})).toThrowError(/missing migrations/)
 
       expect(() => makeAdapter({ migrationsExperimental: [] })).toThrow(
-        /migrationsExperimental has been renamed/,
+        /LokiJSAdapter `migrationsExperimental` option has been renamed to `migrations`/,
+      )
+
+      expect(() => makeAdapter({ experimentalUseIncrementalIndexedDB: false })).toThrow(
+        /LokiJSAdapter `experimentalUseIncrementalIndexedDB` option has been renamed/,
       )
 
       expect(() => adapterWithMigrations({ migrations: [] })).toThrow(/use schemaMigrations()/)

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -37,12 +37,14 @@ export default () => [
       // expect(() => makeAdapter({})).toThrowError(/missing migrations/)
 
       expect(() => makeAdapter({ migrationsExperimental: [] })).toThrow(
-        /LokiJSAdapter `migrationsExperimental` option has been renamed to `migrations`/,
+        /`migrationsExperimental` option has been renamed to `migrations`/,
       )
 
-      expect(() => makeAdapter({ experimentalUseIncrementalIndexedDB: false })).toThrow(
-        /LokiJSAdapter `experimentalUseIncrementalIndexedDB` option has been renamed/,
-      )
+      if (AdapterClass.name === 'LokiJSAdapter') {
+        expect(() => makeAdapter({ experimentalUseIncrementalIndexedDB: false })).toThrow(
+          /LokiJSAdapter `experimentalUseIncrementalIndexedDB` option has been renamed/,
+        )
+      }
 
       expect(() => adapterWithMigrations({ migrations: [] })).toThrow(/use schemaMigrations()/)
 

--- a/src/adapters/common.js
+++ b/src/adapters/common.js
@@ -57,7 +57,7 @@ export function sanitizeQueryResult(
 export function devSetupCallback(result: Result<any>): void {
   if (result.error) {
     logger.error(
-      `[DB] Uh-oh. Database failed to load, we're in big trouble. This might happen if you didn't set up native code correctly (iOS, Android), or if you didn't recompile native app after WatermelonDB update. It might also mean that IndexedDB or SQLite refused to open.`,
+      `[WatermelonDB] Uh-oh. Database failed to load, we're in big trouble. This might happen if you didn't set up native code correctly (iOS, Android), or if you didn't recompile native app after WatermelonDB update. It might also mean that IndexedDB or SQLite refused to open.`,
       result.error,
     )
   }

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { LokiMemoryAdapter } from 'lokijs'
-import { invariant } from '../../utils/common'
+import { invariant, logger } from '../../utils/common'
 import type { ResultCallback } from '../../utils/fp/Result'
 
 import type { RecordId } from '../../Model'
@@ -68,6 +68,16 @@ export default class LokiJSAdapter implements DatabaseAdapter {
     this._dbName = dbName
 
     if (process.env.NODE_ENV !== 'production') {
+      if (options.useWebWorker === undefined) {
+        logger.warn(
+          'LokiJSAdapter `useWebWorker` option will become required in a future version of WatermelonDB. Pass `{ useWebWorker: false }` to adopt the new behavior, or `{ useWebWorker: true }` to supress this warning with no changes',
+        )
+      }
+      if (options.useIncrementalIndexedDB === undefined) {
+        logger.warn(
+          'LokiJSAdapter `useIncrementalIndexedDB` option will become required in a future version of WatermelonDB. Pass `{ useIncrementalIndexedDB: true }` to adopt the new behavior, or `{ useIncrementalIndexedDB: false }` to supress this warning with no changes',
+        )
+      }
       invariant(
         // $FlowFixMe
         options.migrationsExperimental === undefined,

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -68,24 +68,22 @@ export default class LokiJSAdapter implements DatabaseAdapter {
     this._dbName = dbName
 
     if (process.env.NODE_ENV !== 'production') {
-      if (options.useWebWorker === undefined) {
+      if (!('useWebWorker' in options)) {
         logger.warn(
           'LokiJSAdapter `useWebWorker` option will become required in a future version of WatermelonDB. Pass `{ useWebWorker: false }` to adopt the new behavior, or `{ useWebWorker: true }` to supress this warning with no changes',
         )
       }
-      if (options.useIncrementalIndexedDB === undefined) {
+      if (!('useIncrementalIndexedDB' in options)) {
         logger.warn(
           'LokiJSAdapter `useIncrementalIndexedDB` option will become required in a future version of WatermelonDB. Pass `{ useIncrementalIndexedDB: true }` to adopt the new behavior, or `{ useIncrementalIndexedDB: false }` to supress this warning with no changes',
         )
       }
       invariant(
-        // $FlowFixMe
-        options.migrationsExperimental === undefined,
+        !('migrationsExperimental' in options),
         'LokiJSAdapter `migrationsExperimental` option has been renamed to `migrations`',
       )
       invariant(
-        // $FlowFixMe
-        options.experimentalUseIncrementalIndexedDB === undefined,
+        !('experimentalUseIncrementalIndexedDB' in options),
         'LokiJSAdapter `experimentalUseIncrementalIndexedDB` option has been renamed to `useIncrementalIndexedDB`',
       )
       validateAdapter(this)

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -36,10 +36,14 @@ export type LokiAdapterOptions = $Exact<{
   // may lead to lower memory consumption, lower latency, and easier debugging
   useWebWorker?: boolean,
   experimentalUseIncrementalIndexedDB?: boolean,
-  // Called when internal IDB version changed (most likely the database was deleted in another browser tab)
+  // Called when internal IndexedDB version changed (most likely the database was deleted in another browser tab)
   // Pass a callback to force log out in this copy of the app as well
   // Note that this only works when using incrementalIDB and not using web workers
   onIndexedDBVersionChange?: () => void,
+  // Called when underlying IndexedDB encountered a quota exceeded error (ran out of allotted disk space for app)
+  // This means that app can't save more data or that it will fall back to using in-memory database only
+  // Note that this only works when `useWebWorker: false`
+  onQuotaExceededError?: (error: Error) => void,
   // -- internal --
   _testLokiAdapter?: LokiMemoryAdapter,
 }>

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -35,7 +35,7 @@ export type LokiAdapterOptions = $Exact<{
   // (true by default) Although web workers may have some throughput benefits, disabling them
   // may lead to lower memory consumption, lower latency, and easier debugging
   useWebWorker?: boolean,
-  experimentalUseIncrementalIndexedDB?: boolean,
+  useIncrementalIndexedDB?: boolean,
   // Called when internal IndexedDB version changed (most likely the database was deleted in another browser tab)
   // Pass a callback to force log out in this copy of the app as well
   // Note that this only works when using incrementalIDB and not using web workers
@@ -71,7 +71,12 @@ export default class LokiJSAdapter implements DatabaseAdapter {
       invariant(
         // $FlowFixMe
         options.migrationsExperimental === undefined,
-        'LokiJSAdapter migrationsExperimental has been renamed to migrations',
+        'LokiJSAdapter `migrationsExperimental` option has been renamed to `migrations`',
+      )
+      invariant(
+        // $FlowFixMe
+        options.experimentalUseIncrementalIndexedDB === undefined,
+        'LokiJSAdapter `experimentalUseIncrementalIndexedDB` option has been renamed to `useIncrementalIndexedDB`',
       )
       validateAdapter(this)
     }

--- a/src/adapters/lokijs/worker/executor.js
+++ b/src/adapters/lokijs/worker/executor.js
@@ -37,6 +37,8 @@ export default class LokiExecutor {
 
   onIndexedDBVersionChange: ?() => void
 
+  onQuotaExceededError: ?(error: Error) => void
+
   _testLokiAdapter: ?LokiMemoryAdapter
 
   cachedRecords: Map<TableName<any>, Set<RecordId>> = new Map()
@@ -48,6 +50,7 @@ export default class LokiExecutor {
     this.migrations = migrations
     this.experimentalUseIncrementalIndexedDB = options.experimentalUseIncrementalIndexedDB || false
     this.onIndexedDBVersionChange = options.onIndexedDBVersionChange
+    this.onQuotaExceededError = options.onQuotaExceededError
     this._testLokiAdapter = _testLokiAdapter
   }
 
@@ -240,6 +243,7 @@ export default class LokiExecutor {
       this._testLokiAdapter,
       this.experimentalUseIncrementalIndexedDB,
       this.onIndexedDBVersionChange,
+      this.onQuotaExceededError,
     )
 
     logger.log('[WatermelonDB][Loki] Database loaded')

--- a/src/adapters/lokijs/worker/executor.js
+++ b/src/adapters/lokijs/worker/executor.js
@@ -33,7 +33,7 @@ export default class LokiExecutor {
 
   loki: Loki
 
-  experimentalUseIncrementalIndexedDB: boolean
+  useIncrementalIndexedDB: boolean
 
   onIndexedDBVersionChange: ?() => void
 
@@ -48,7 +48,7 @@ export default class LokiExecutor {
     this.dbName = dbName
     this.schema = schema
     this.migrations = migrations
-    this.experimentalUseIncrementalIndexedDB = options.experimentalUseIncrementalIndexedDB || false
+    this.useIncrementalIndexedDB = options.useIncrementalIndexedDB || false
     this.onIndexedDBVersionChange = options.onIndexedDBVersionChange
     this.onQuotaExceededError = options.onQuotaExceededError
     this._testLokiAdapter = _testLokiAdapter
@@ -241,7 +241,7 @@ export default class LokiExecutor {
     this.loki = await newLoki(
       this.dbName,
       this._testLokiAdapter,
-      this.experimentalUseIncrementalIndexedDB,
+      this.useIncrementalIndexedDB,
       this.onIndexedDBVersionChange,
       this.onQuotaExceededError,
     )

--- a/src/adapters/lokijs/worker/lokiExtensions.js
+++ b/src/adapters/lokijs/worker/lokiExtensions.js
@@ -18,11 +18,15 @@ const isIDBAvailable = () => {
       db.close()
       resolve(true)
     }
-    checkRequest.onerror = e => {
+    checkRequest.onerror = event => {
       logger.error(
-        '[WatermelonDB] IndexedDB checker failed to open. Most likely, user is in Private Mode. It could also be a quota exceeded error. Will fall back to in-memory database.',
-        e,
+        '[WatermelonDB][Loki] IndexedDB checker failed to open. Most likely, user is in Private Mode. It could also be a quota exceeded error. Will fall back to in-memory database.',
+        event,
       )
+      const error: ?Error = event?.target?.error
+      if (error && error.name === 'QuotaExceededError') {
+        logger.log('[WatermelonDB][Loki] Looks like disk quota was exceeded: ', error)
+      }
       resolve(false)
     }
     checkRequest.onblocked = () => {

--- a/src/adapters/lokijs/worker/lokiExtensions.js
+++ b/src/adapters/lokijs/worker/lokiExtensions.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-undef */
 
 import Loki, { LokiMemoryAdapter } from 'lokijs'
+import { logger } from '../../../utils/common'
 
 const isIDBAvailable = () => {
   return new Promise(resolve => {
@@ -17,12 +18,15 @@ const isIDBAvailable = () => {
       db.close()
       resolve(true)
     }
-    checkRequest.onerror = () => {
+    checkRequest.onerror = e => {
+      logger.error(
+        '[WatermelonDB] IndexedDB checker failed to open. Most likely, user is in Private Mode. It could also be a quota exceeded error. Will fall back to in-memory database.',
+        e,
+      )
       resolve(false)
     }
     checkRequest.onblocked = () => {
-      // eslint-disable-next-line no-console
-      console.error('WatermelonIDBChecker call is blocked')
+      logger.error('[WatermelonDB] IndexedDB checker call is blocked')
     }
   })
 }
@@ -31,7 +35,7 @@ async function getLokiAdapter(
   name: ?string,
   adapter: ?LokiMemoryAdapter,
   useIncrementalIDB: boolean,
-  onIndexedDBVersionChange: ?(() => void),
+  onIndexedDBVersionChange: ?() => void,
 ): mixed {
   if (adapter) {
     return adapter
@@ -55,7 +59,7 @@ export async function newLoki(
   name: ?string,
   adapter: ?LokiMemoryAdapter,
   useIncrementalIDB: boolean,
-  onIndexedDBVersionChange: ?(() => void),
+  onIndexedDBVersionChange: ?() => void,
 ): Loki {
   const loki = new Loki(name, {
     adapter: await getLokiAdapter(name, adapter, useIncrementalIDB, onIndexedDBVersionChange),

--- a/src/adapters/lokijs/worker/lokiExtensions.js
+++ b/src/adapters/lokijs/worker/lokiExtensions.js
@@ -19,11 +19,15 @@ const isIDBAvailable = () => {
       resolve(true)
     }
     checkRequest.onerror = event => {
+      const error: ?Error = event?.target?.error
+      // this is what Firefox in Private Mode returns:
+      // DOMException: "A mutation operation was attempted on a database that did not allow mutations."
+      // code: 11, name: InvalidStateError
       logger.error(
         '[WatermelonDB][Loki] IndexedDB checker failed to open. Most likely, user is in Private Mode. It could also be a quota exceeded error. Will fall back to in-memory database.',
         event,
+        error,
       )
-      const error: ?Error = event?.target?.error
       if (error && error.name === 'QuotaExceededError') {
         logger.log('[WatermelonDB][Loki] Looks like disk quota was exceeded: ', error)
       }

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -219,8 +219,7 @@ export default class SQLiteAdapter implements DatabaseAdapter, SQLDatabaseAdapte
 
     if (process.env.NODE_ENV !== 'production') {
       invariant(
-        // $FlowFixMe
-        options.migrationsExperimental === undefined,
+        !('migrationsExperimental' in options),
         'SQLiteAdapter `migrationsExperimental` option has been renamed to `migrations`',
       )
       invariant(

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -282,13 +282,15 @@ export default class SQLiteAdapter implements DatabaseAdapter, SQLDatabaseAdapte
   }
 
   async _setUpWithMigrations(databaseVersion: SchemaVersion): Promise<void> {
-    logger.log('[DB] Database needs migrations')
+    logger.log('[WatermelonDB][SQLite] Database needs migrations')
     invariant(databaseVersion > 0, 'Invalid database schema version')
 
     const migrationSteps = this._migrationSteps(databaseVersion)
 
     if (migrationSteps) {
-      logger.log(`[DB] Migrating from version ${databaseVersion} to ${this.schema.version}...`)
+      logger.log(
+        `[WatermelonDB][SQLite] Migrating from version ${databaseVersion} to ${this.schema.version}...`,
+      )
 
       try {
         await toPromise(callback =>
@@ -301,21 +303,23 @@ export default class SQLiteAdapter implements DatabaseAdapter, SQLDatabaseAdapte
             callback,
           ),
         )
-        logger.log('[DB] Migration successful')
+        logger.log('[WatermelonDB][SQLite] Migration successful')
       } catch (error) {
-        logger.error('[DB] Migration failed', error)
+        logger.error('[WatermelonDB][SQLite] Migration failed', error)
         throw error
       }
     } else {
       logger.warn(
-        '[DB] Migrations not available for this version range, resetting database instead',
+        '[WatermelonDB][SQLite] Migrations not available for this version range, resetting database instead',
       )
       await this._setUpWithSchema()
     }
   }
 
   async _setUpWithSchema(): Promise<void> {
-    logger.log(`[DB] Setting up database with schema version ${this.schema.version}`)
+    logger.log(
+      `[WatermelonDB][SQLite] Setting up database with schema version ${this.schema.version}`,
+    )
     await toPromise(callback =>
       this._dispatcher.setUpWithSchema(
         this._tag,
@@ -325,7 +329,7 @@ export default class SQLiteAdapter implements DatabaseAdapter, SQLDatabaseAdapte
         callback,
       ),
     )
-    logger.log(`[DB] Schema set up successfully`)
+    logger.log(`[WatermelonDB][SQLite] Schema set up successfully`)
   }
 
   find(table: TableName<any>, id: RecordId, callback: ResultCallback<CachedFindResult>): void {
@@ -407,7 +411,7 @@ export default class SQLiteAdapter implements DatabaseAdapter, SQLDatabaseAdapte
       this.schema.version,
       result => {
         if (result.value) {
-          logger.log('[DB] Database is now reset')
+          logger.log('[WatermelonDB][SQLite] Database is now reset')
         }
         callback(result)
       },

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -221,7 +221,7 @@ export default class SQLiteAdapter implements DatabaseAdapter, SQLDatabaseAdapte
       invariant(
         // $FlowFixMe
         options.migrationsExperimental === undefined,
-        'SQLiteAdapter migrationsExperimental has been renamed to migrations',
+        'SQLiteAdapter `migrationsExperimental` option has been renamed to `migrations`',
       )
       invariant(
         NativeDatabaseBridge,

--- a/src/observation/subscribeToQueryReloading/index.js
+++ b/src/observation/subscribeToQueryReloading/index.js
@@ -28,7 +28,7 @@ export default function subscribeToQueryReloading<Record: Model>(
     }
 
     collection._fetchQuery(query, result => {
-      if (!result.value) {
+      if (result.error) {
         logError(result.error.toString())
         return
       }

--- a/src/observation/subscribeToQueryReloading/index.js
+++ b/src/observation/subscribeToQueryReloading/index.js
@@ -24,7 +24,7 @@ export default function subscribeToQueryReloading<Record: Model>(
 
   function reloadingObserverFetch(): void {
     if (shouldEmitStatus) {
-      subscriber((false: any))
+      !unsubscribed && subscriber((false: any))
     }
 
     collection._fetchQuery(query, result => {

--- a/src/observation/subscribeToSimpleQuery/index.js
+++ b/src/observation/subscribeToSimpleQuery/index.js
@@ -74,7 +74,7 @@ export default function subscribeToSimpleQuery<Record: Model>(
 
     // Send initial matching records
     const matchingRecords: Record[] = initialRecords
-    const emitCopy = () => subscriber(matchingRecords.slice(0))
+    const emitCopy = () => !unsubscribed && subscriber(matchingRecords.slice(0))
     emitCopy()
 
     // Observe changes to the collection

--- a/src/observation/subscribeToSimpleQuery/index.js
+++ b/src/observation/subscribeToSimpleQuery/index.js
@@ -65,7 +65,7 @@ export default function subscribeToSimpleQuery<Record: Model>(
       return
     }
 
-    if (!result.value) {
+    if (result.error) {
       logError(result.error.toString())
       return
     }


### PR DESCRIPTION
- Speculative unsubscribed checks
- Clean up logger calls a little
- Better error handling for failed database open
- Add onQuotaExceededError hook
- Fix "was sent over the bridge, but it's not cached" issue
- Breaking renames + preparation for future breaking change