### PR TITLE
Fix simple observer bug

### DIFF
--- a/src/observation/subscribeToSimpleQuery/index.js
+++ b/src/observation/subscribeToSimpleQuery/index.js
@@ -77,6 +77,11 @@ export default function subscribeToSimpleQuery<Record: Model>(
     const emitCopy = () => subscriber(matchingRecords.slice(0))
     emitCopy()
 
+    // Check if emitCopy haven't completed source observable to avoid memory leaks
+    if (unsubscribed) {
+      return
+    }
+
     // Observe changes to the collection
     unsubscribe = query.collection.experimentalSubscribe(function observeQueryCollectionChanged(
       changeSet,


### PR DESCRIPTION
It fixes a bug in simple observation introduced with recent changes. Sometimes after initial emission but before subscribing to observe changes source observable might complete and call cleanup function leading to possible memory leaks.

In NT it only happens on native when using `first` and `toPromise` on observable. I am not sure why. I think it might be because of Promise implementation. However there are probably more edge cases where this bug will occur. 

I haven't added regression tests since I am not sure how to test this properly yet :/ I will try to add one later this week.