### PR TITLE
Fix Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - [LokiJS] Fixed an issue preventing database from saving when using `experimentalUseIncrementalIndexedDB`
 - Fixed a potential issue when using `database.unsafeResetDatabase()`
 - [iOS] Fixed issue with clearing database under experimental synchronous mode
+- [Typescript] Fixed types of decorators.
 
 ### New features (Experimental)
 

--- a/src/decorators/action/index.d.ts
+++ b/src/decorators/action/index.d.ts
@@ -1,4 +1,8 @@
 declare module '@nozbe/watermelondb/decorators/action' {
-  const action: MethodDecorator
+
+  // Copied from lib.es5.d.ts, MethodDecorator
+  function action<T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> | void;
+  function action(): MethodDecorator;
+
   export default action
 }

--- a/src/decorators/children/index.d.ts
+++ b/src/decorators/children/index.d.ts
@@ -1,7 +1,6 @@
 declare module '@nozbe/watermelondb/decorators/children' {
   import { TableName } from '@nozbe/watermelondb'
-  import { Decorator, RawDecorator } from '@nozbe/watermelondb/utils/common/makeDecorator'
 
-  const children: Decorator<[TableName<any>], (childTable: TableName<any>) => RawDecorator>
+  const children: (childTable: TableName<any>) => PropertyDecorator
   export default children
 }

--- a/src/decorators/date/index.d.ts
+++ b/src/decorators/date/index.d.ts
@@ -1,7 +1,6 @@
 declare module '@nozbe/watermelondb/decorators/date' {
-  import { Decorator, RawDecorator } from '@nozbe/watermelondb/utils/common/makeDecorator'
   import { ColumnName } from '@nozbe/watermelondb'
 
-  const date: Decorator<[ColumnName], (columnName: ColumnName) => RawDecorator>
+  const date: (columnName: ColumnName) => PropertyDecorator
   export default date
 }

--- a/src/decorators/field/index.d.ts
+++ b/src/decorators/field/index.d.ts
@@ -1,7 +1,6 @@
 declare module '@nozbe/watermelondb/decorators/field' {
-  import { Decorator, RawDecorator } from '@nozbe/watermelondb/utils/common/makeDecorator'
   import { ColumnName } from '@nozbe/watermelondb'
 
-  const field: Decorator<[ColumnName], (columnName: ColumnName) => RawDecorator>
+  const field: (columnName: ColumnName) => PropertyDecorator
   export default field
 }

--- a/src/decorators/immutableRelation/index.d.ts
+++ b/src/decorators/immutableRelation/index.d.ts
@@ -1,11 +1,7 @@
 declare module '@nozbe/watermelondb/decorators/immutableRelation' {
   import { ColumnName, TableName } from '@nozbe/watermelondb'
-  import { Decorator, RawDecorator } from '@nozbe/watermelondb/utils/common/makeDecorator'
 
-  const immutableRelation: Decorator<
-    [TableName<any>, ColumnName],
-    (relationTable: TableName<any>, relationIdColumn: ColumnName) => RawDecorator
-  >
+  const immutableRelation: (relationTable: TableName<any>, relationIdColumn: ColumnName) => PropertyDecorator;
 
   export default immutableRelation
 }

--- a/src/decorators/json/index.d.ts
+++ b/src/decorators/json/index.d.ts
@@ -1,13 +1,9 @@
 declare module '@nozbe/watermelondb/decorators/json' {
   import { ColumnName, Model } from '@nozbe/watermelondb'
-  import { Decorator, RawDecorator } from '@nozbe/watermelondb/utils/common/makeDecorator'
 
   type Sanitizer = (source: any, model?: Model) => any
 
-  const json: Decorator<
-    [ColumnName, Sanitizer],
-    (rawFieldName: ColumnName, sanitizer: Sanitizer) => RawDecorator
-  >
+  const json: (rawFieldName: ColumnName, sanitizer: Sanitizer) => PropertyDecorator
 
   export default json
 }

--- a/src/decorators/lazy/index.d.ts
+++ b/src/decorators/lazy/index.d.ts
@@ -1,4 +1,6 @@
 declare module '@nozbe/watermelondb/decorators/lazy' {
-  const lazy: PropertyDecorator
+  // Copied from lib.es5.d.ts, PropertyDecorator
+  function lazy(target: Object, propertyKey: string | symbol): void;
+  function lazy(): PropertyDecorator;
   export default lazy
 }

--- a/src/decorators/nochange/index.d.ts
+++ b/src/decorators/nochange/index.d.ts
@@ -1,5 +1,8 @@
 declare module '@nozbe/watermelondb/decorators/nochange' {
-  const nochange: PropertyDecorator
+
+  // Copied from lib.es5.d.ts, PropertyDecorator
+  function nochange(target: Object, propertyKey: string | symbol): void;
+  function nochange(): PropertyDecorator;
 
   export default nochange
 }

--- a/src/decorators/nochange/index.d.ts
+++ b/src/decorators/nochange/index.d.ts
@@ -1,7 +1,5 @@
 declare module '@nozbe/watermelondb/decorators/nochange' {
-  import { Decorator, RawDecorator } from '@nozbe/watermelondb/utils/common/makeDecorator'
-
-  const nochange: Decorator<[], () => RawDecorator>
+  const nochange: PropertyDecorator
 
   export default nochange
 }

--- a/src/decorators/readonly/index.d.ts
+++ b/src/decorators/readonly/index.d.ts
@@ -1,7 +1,5 @@
 declare module '@nozbe/watermelondb/decorators/readonly' {
-  import { Decorator, RawDecorator } from '@nozbe/watermelondb/utils/common/makeDecorator'
-
-  const readonly: Decorator<[], () => RawDecorator>
+  const readonly: PropertyDecorator
 
   export default readonly
 }

--- a/src/decorators/readonly/index.d.ts
+++ b/src/decorators/readonly/index.d.ts
@@ -1,5 +1,8 @@
 declare module '@nozbe/watermelondb/decorators/readonly' {
-  const readonly: PropertyDecorator
+
+  // Copied from lib.es5.d.ts, PropertyDecorator
+  function readonly(target: Object, propertyKey: string | symbol): void;
+  function readonly(): PropertyDecorator;
 
   export default readonly
 }

--- a/src/decorators/relation/index.d.ts
+++ b/src/decorators/relation/index.d.ts
@@ -1,16 +1,13 @@
 declare module '@nozbe/watermelondb/decorators/relation' {
   import { ColumnName, TableName } from '@nozbe/watermelondb'
-  import { Decorator, RawDecorator } from '@nozbe/watermelondb/utils/common/makeDecorator'
   import { Options } from '@nozbe/watermelondb/Relation'
 
-  const relation: Decorator<
-    [TableName<any>, ColumnName, Options | void],
-    (
-      relationTable: TableName<any>,
-      relationIdColumn: ColumnName,
-      options: Options | void,
-    ) => RawDecorator
-  >
+  const relation: (
+    relationTable: TableName<any>,
+    relationIdColumn: ColumnName,
+    options?: Options,
+  ) => PropertyDecorator
+
 
   export default relation
 }

--- a/src/decorators/text/index.d.ts
+++ b/src/decorators/text/index.d.ts
@@ -1,8 +1,7 @@
 declare module '@nozbe/watermelondb/decorators/text' {
   import { ColumnName } from '@nozbe/watermelondb'
-  import { Decorator, RawDecorator } from '@nozbe/watermelondb/utils/common/makeDecorator'
 
-  const text: Decorator<[ColumnName], (columnName: ColumnName) => RawDecorator>
+  const text: (columnName: ColumnName) => PropertyDecorator
 
   export default text
 }


### PR DESCRIPTION
So the original rationale being these types was that they followed flow types.
But certain things are not supported in both. So they might vary from time to time.

🍉 supports both `@nochange fieldName` and `@nochange() fieldName`. Tested both works now.

Fixes https://github.com/Nozbe/WatermelonDB/issues/559
