### PR TITLE
Sort take skip query operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 - [Database] Added experimental `database.experimentalSubscribe(['table1', 'table2'], () => { ... })` method as a vanilla JS alternative to Rx-based `database.withChangesForTables()`. Unlike the latter, `experimentalSubscribe` notifies the subscriber only once after a batch that makes a change in multiple collections subscribed to. It also doesn't notify the subscriber immediately upon subscription, and doesn't send details about the changes, only a signal.
 - Added `experimentalDisableObserveCountThrottling()` to `@nozbe/watermelondb/observation/observeCount` that globally disables count observation throttling. We think that throttling on WatermelonDB level is not a good feature and will be removed in a future release - and will be better implemented on app level if necessary
 - [Query] Added experimental `query.experimentalSubscribe(records => { ... })`, `query.experimentalSubscribeWithColumns(['col1', 'col2'], records => { ... })`, and `query.experimentalSubscribeToCount(count => { ... })` methods
+- [Query] Added experimental `Q.sortBy(sortColumn, sortOrder)`, `Q.take(count)`, `Q.skip(count)` methods
 
 ## 0.15 - 2019-11-08
 

--- a/src/Collection/index.d.ts
+++ b/src/Collection/index.d.ts
@@ -1,6 +1,6 @@
 declare module '@nozbe/watermelondb/Collection' {
   import { Database, Model, Query, RecordId, TableName, TableSchema } from '@nozbe/watermelondb'
-  import { Condition } from '@nozbe/watermelondb/QueryDescription'
+  import { Clause } from '@nozbe/watermelondb/QueryDescription'
   import { Class } from '@nozbe/watermelondb/utils/common'
   import { Observable, Subject } from 'rxjs'
 
@@ -26,7 +26,7 @@ declare module '@nozbe/watermelondb/Collection' {
 
     public findAndObserve(id: RecordId): Observable<Record>
 
-    public query(...conditions: Condition[]): Query<Record>
+    public query(...conditions: Clause[]): Query<Record>
 
     public unsafeFetchRecordsWithSQL(sql: string): Promise<Record[]>
 

--- a/src/Collection/index.js
+++ b/src/Collection/index.js
@@ -12,7 +12,7 @@ import { type Unsubscribe } from '../utils/subscriptions'
 import Query from '../Query'
 import type Database from '../Database'
 import type Model, { RecordId } from '../Model'
-import type { Condition } from '../QueryDescription'
+import type { Clause } from '../QueryDescription'
 import { type TableName, type TableSchema } from '../Schema'
 import { type DirtyRaw } from '../RawRecord'
 
@@ -56,8 +56,8 @@ export default class Collection<Record: Model> {
   }
 
   // Query records of this type
-  query(...conditions: Condition[]): Query<Record> {
-    return new Query(this, conditions)
+  query(...clauses: Clause[]): Query<Record> {
+    return new Query(this, clauses)
   }
 
   // Creates a new record in this collection

--- a/src/Query/index.d.ts
+++ b/src/Query/index.d.ts
@@ -1,7 +1,7 @@
 declare module '@nozbe/watermelondb/Query' {
   import { Collection, ColumnName, Model, TableName } from '@nozbe/watermelondb'
   import { AssociationInfo } from '@nozbe/watermelondb/Model'
-  import { Condition, QueryDescription } from '@nozbe/watermelondb/QueryDescription'
+  import { Clause, QueryDescription } from '@nozbe/watermelondb/QueryDescription'
   import { Observable } from 'rxjs'
 
   export type AssociationArgs = [TableName<any>, AssociationInfo]
@@ -16,7 +16,7 @@ declare module '@nozbe/watermelondb/Query' {
 
     public description: QueryDescription
 
-    public extend(...conditions: Condition[]): Query<Record>
+    public extend(...conditions: Clause[]): Query<Record>
 
     public pipe<T>(transform: (this: this) => T): T
 

--- a/src/Query/index.js
+++ b/src/Query/index.js
@@ -14,7 +14,7 @@ import subscribeToCount from '../observation/subscribeToCount'
 import subscribeToQuery from '../observation/subscribeToQuery'
 import subscribeToQueryWithColumns from '../observation/subscribeToQueryWithColumns'
 import { buildQueryDescription, queryWithoutDeleted } from '../QueryDescription'
-import type { Condition, QueryDescription } from '../QueryDescription'
+import type { Clause, QueryDescription } from '../QueryDescription'
 import type Model, { AssociationInfo } from '../Model'
 import type Collection from '../Collection'
 import type { TableName, ColumnName } from '../Schema'
@@ -51,18 +51,18 @@ export default class Query<Record: Model> {
   )
 
   // Note: Don't use this directly, use Collection.query(...)
-  constructor(collection: Collection<Record>, conditions: Condition[]): void {
+  constructor(collection: Collection<Record>, clauses: Clause[]): void {
     this.collection = collection
-    this._rawDescription = buildQueryDescription(conditions)
+    this._rawDescription = buildQueryDescription(clauses)
     this.description = queryWithoutDeleted(this._rawDescription)
   }
 
-  // Creates a new Query that extends the conditions of this query
-  extend(...conditions: Condition[]): Query<Record> {
+  // Creates a new Query that extends the clauses of this query
+  extend(...clauses: Clause[]): Query<Record> {
     const { collection } = this
     const { join, where } = this._rawDescription
 
-    return new Query(collection, [...join, ...where, ...conditions])
+    return new Query(collection, [...join, ...where, ...clauses])
   }
 
   pipe<T>(transform: this => T): T {
@@ -160,7 +160,7 @@ export default class Query<Record: Model> {
     return getAssociations(this.secondaryTables, this.modelClass.associations)
   }
 
-  // `true` if query contains conditions on foreign tables
+  // `true` if query contains join clauses on foreign tables
   get hasJoins(): boolean {
     return !!this.description.join.length
   }

--- a/src/Query/index.js
+++ b/src/Query/index.js
@@ -60,9 +60,14 @@ export default class Query<Record: Model> {
   // Creates a new Query that extends the clauses of this query
   extend(...clauses: Clause[]): Query<Record> {
     const { collection } = this
-    const { join, where } = this._rawDescription
+    const { join, where, sortBy, take, skip } = this._rawDescription
 
-    return new Query(collection, [...join, ...where, ...clauses])
+    return new Query(collection, [
+      ...join, ...where, ...sortBy,
+      ...(take ? [take] : []),
+      ...(skip ? [skip] : []),
+      ...clauses
+    ])
   }
 
   pipe<T>(transform: this => T): T {

--- a/src/Query/test.js
+++ b/src/Query/test.js
@@ -81,6 +81,54 @@ describe('Query description properties', () => {
     expect(extendedQuery.hasJoins).toBe(expectedQuery.hasJoins)
     expect(extendedQuery._rawDescription).toEqual(expectedQuery._rawDescription)
   })
+  it('can return extended query for sortBy, take and skip', () => {
+    const query = new Query(mockCollection, [
+      Q.sortBy('sortable', Q.desc),
+      Q.skip(60),
+      Q.take(20),
+    ])
+    const extendedQuery = query.extend(
+      Q.sortBy('sortable2'),
+      Q.skip(40),
+      Q.take(10),
+    )
+    const expectedQuery = new Query(mockCollection, [
+      Q.sortBy('sortable', Q.desc),
+      Q.sortBy('sortable2', Q.asc),
+      Q.skip(40),
+      Q.take(10),
+    ])
+    expect(extendedQuery.collection).toBe(expectedQuery.collection)
+    expect(extendedQuery.modelClass).toBe(expectedQuery.modelClass)
+    expect(extendedQuery.description).toEqual(expectedQuery.description)
+    expect(extendedQuery.secondaryTables).toEqual(expectedQuery.secondaryTables)
+    expect(extendedQuery.associations).toEqual(expectedQuery.associations)
+    expect(extendedQuery.hasJoins).toBe(expectedQuery.hasJoins)
+    expect(extendedQuery._rawDescription).toEqual(expectedQuery._rawDescription)
+  })
+  it('can return extended query and leave take and skip clauses intact', () => {
+    const query = new Query(mockCollection, [
+      Q.sortBy('sortable', Q.desc),
+      Q.skip(60),
+      Q.take(20),
+    ])
+    const extendedQuery = query.extend(
+      Q.sortBy('sortable2'),
+    )
+    const expectedQuery = new Query(mockCollection, [
+      Q.sortBy('sortable', Q.desc),
+      Q.sortBy('sortable2', Q.asc),
+      Q.skip(60),
+      Q.take(20),
+    ])
+    expect(extendedQuery.collection).toBe(expectedQuery.collection)
+    expect(extendedQuery.modelClass).toBe(expectedQuery.modelClass)
+    expect(extendedQuery.description).toEqual(expectedQuery.description)
+    expect(extendedQuery.secondaryTables).toEqual(expectedQuery.secondaryTables)
+    expect(extendedQuery.associations).toEqual(expectedQuery.associations)
+    expect(extendedQuery.hasJoins).toBe(expectedQuery.hasJoins)
+    expect(extendedQuery._rawDescription).toEqual(expectedQuery._rawDescription)
+  })
   it('returns serializable version of Query', () => {
     const query = new Query(mockCollection, [
       Q.on('projects', 'team_id', 'abcdef'),

--- a/src/Query/test.js
+++ b/src/Query/test.js
@@ -83,20 +83,20 @@ describe('Query description properties', () => {
   })
   it('can return extended query for sortBy, take and skip', () => {
     const query = new Query(mockCollection, [
-      Q.sortBy('sortable', Q.desc),
-      Q.skip(60),
-      Q.take(20),
+      Q.experimentalSortBy('sortable', Q.desc),
+      Q.experimentalSkip(60),
+      Q.experimentalTake(20),
     ])
     const extendedQuery = query.extend(
-      Q.sortBy('sortable2'),
-      Q.skip(40),
-      Q.take(10),
+      Q.experimentalSortBy('sortable2'),
+      Q.experimentalSkip(40),
+      Q.experimentalTake(10),
     )
     const expectedQuery = new Query(mockCollection, [
-      Q.sortBy('sortable', Q.desc),
-      Q.sortBy('sortable2', Q.asc),
-      Q.skip(40),
-      Q.take(10),
+      Q.experimentalSortBy('sortable', Q.desc),
+      Q.experimentalSortBy('sortable2', Q.asc),
+      Q.experimentalSkip(40),
+      Q.experimentalTake(10),
     ])
     expect(extendedQuery.collection).toBe(expectedQuery.collection)
     expect(extendedQuery.modelClass).toBe(expectedQuery.modelClass)
@@ -108,18 +108,18 @@ describe('Query description properties', () => {
   })
   it('can return extended query and leave take and skip clauses intact', () => {
     const query = new Query(mockCollection, [
-      Q.sortBy('sortable', Q.desc),
-      Q.skip(60),
-      Q.take(20),
+      Q.experimentalSortBy('sortable', Q.desc),
+      Q.experimentalSkip(60),
+      Q.experimentalTake(20),
     ])
     const extendedQuery = query.extend(
-      Q.sortBy('sortable2'),
+      Q.experimentalSortBy('sortable2'),
     )
     const expectedQuery = new Query(mockCollection, [
-      Q.sortBy('sortable', Q.desc),
-      Q.sortBy('sortable2', Q.asc),
-      Q.skip(60),
-      Q.take(20),
+      Q.experimentalSortBy('sortable', Q.desc),
+      Q.experimentalSortBy('sortable2', Q.asc),
+      Q.experimentalSkip(60),
+      Q.experimentalTake(20),
     ])
     expect(extendedQuery.collection).toBe(expectedQuery.collection)
     expect(extendedQuery.modelClass).toBe(expectedQuery.modelClass)

--- a/src/QueryDescription/index.d.ts
+++ b/src/QueryDescription/index.d.ts
@@ -49,10 +49,29 @@ declare module '@nozbe/watermelondb/QueryDescription' {
     left: ColumnName
     comparison: Comparison
   }
-  export type Condition = Where | On
+  export interface SortBy {
+    type: 'sortBy'
+    sortColumn: ColumnName
+    sortOrder: SortOrder
+  }
+  export type SortOrder =
+    | 'asc'
+    | 'desc'
+  export interface Take {
+    type: 'take'
+    count: number
+  }
+  export interface Skip = {
+    type: 'skip'
+    count: number
+  }
+  export type Condition = Where | On | SortBy | Take | Skip
   export interface QueryDescription {
     where: Where[]
     join: On[]
+    sortBy: SortBy[]
+    take?: Take
+    skip?: Skip
   }
 
   export function eq(valueOrColumn: Value | ColumnDescription): Comparison
@@ -71,6 +90,9 @@ declare module '@nozbe/watermelondb/QueryDescription' {
   export function or(...conditions: Where[]): Or
   export function like(value: string): Comparison
   export function notLike(value: string): Comparison
+  export function sortBy(sortColumn: ColumnName, sortOrder?: SortOrder): SortBy
+  export function take(count: number): Take
+  export function skip(count: number): Skip
   export function sanitizeLikeString(value: string): string
 
   type _OnFunctionColumnValue = (table: TableName<any>, column: ColumnName, value: Value) => On

--- a/src/QueryDescription/index.d.ts
+++ b/src/QueryDescription/index.d.ts
@@ -65,7 +65,7 @@ declare module '@nozbe/watermelondb/QueryDescription' {
     type: 'skip'
     count: number
   }
-  export type Condition = Where | On | SortBy | Take | Skip
+  export type Clause = Where | On | SortBy | Take | Skip
   export interface QueryDescription {
     where: Where[]
     join: On[]
@@ -109,7 +109,7 @@ declare module '@nozbe/watermelondb/QueryDescription' {
 
   export const on: OnFunction
 
-  export function buildQueryDescription(conditions: Condition[]): QueryDescription
+  export function buildQueryDescription(conditions: Clause[]): QueryDescription
   export function queryWithoutDeleted(query: QueryDescription): QueryDescription
   export function hasColumnComparisons(conditions: Where[]): boolean
 }

--- a/src/QueryDescription/index.d.ts
+++ b/src/QueryDescription/index.d.ts
@@ -57,11 +57,13 @@ declare module '@nozbe/watermelondb/QueryDescription' {
   export type SortOrder =
     | 'asc'
     | 'desc'
+  export const asc: SortOrder
+  export const desc: SortOrder
   export interface Take {
     type: 'take'
     count: number
   }
-  export interface Skip = {
+  export interface Skip {
     type: 'skip'
     count: number
   }

--- a/src/QueryDescription/index.d.ts
+++ b/src/QueryDescription/index.d.ts
@@ -92,9 +92,9 @@ declare module '@nozbe/watermelondb/QueryDescription' {
   export function or(...conditions: Where[]): Or
   export function like(value: string): Comparison
   export function notLike(value: string): Comparison
-  export function sortBy(sortColumn: ColumnName, sortOrder?: SortOrder): SortBy
-  export function take(count: number): Take
-  export function skip(count: number): Skip
+  export function experimentalSortBy(sortColumn: ColumnName, sortOrder?: SortOrder): SortBy
+  export function experimentalTake(count: number): Take
+  export function experimentalSkip(count: number): Skip
   export function sanitizeLikeString(value: string): string
 
   type _OnFunctionColumnValue = (table: TableName<any>, column: ColumnName, value: Value) => On

--- a/src/QueryDescription/index.js
+++ b/src/QueryDescription/index.js
@@ -53,6 +53,8 @@ export type On = $RE<{
 export type SortOrder =
   | 'asc'
   | 'desc'
+export const asc: SortOrder = 'asc'
+export const desc: SortOrder = 'desc'
 export type SortBy = $RE<{
   type: 'sortBy',
   sortColumn: ColumnName,

--- a/src/QueryDescription/index.js
+++ b/src/QueryDescription/index.js
@@ -221,17 +221,19 @@ export function or(...conditions: Where[]): Or {
   return { type: 'or', conditions }
 }
 
-export function sortBy(sortColumn: ColumnName, sortOrder: SortOrder = asc): SortBy {
+function sortBy(sortColumn: ColumnName, sortOrder: SortOrder = asc): SortBy {
   return { type: 'sortBy', sortColumn, sortOrder }
 }
 
-export function take(count: number): Take {
+function take(count: number): Take {
   return { type: 'take', count }
 }
 
-export function skip(count: number): Skip {
+function skip(count: number): Skip {
   return { type: 'skip', count }
 }
+
+export { sortBy as experimentalSortBy, take as experimentalTake, skip as experimentalSkip }
 
 // Note: we have to write out three separate meanings of OnFunction because of a Babel bug
 // (it will remove the parentheses, changing the meaning of the flow type)

--- a/src/QueryDescription/index.js
+++ b/src/QueryDescription/index.js
@@ -271,13 +271,6 @@ const extractClauses: (Clause[]) => QueryDescription = clauses => {
   clauses.forEach(cond => {
     let { type } = cond
     switch (type) {
-      case 'on':
-        type = 'join'
-        // fallthrough
-      case 'sortBy':
-        // $FlowFixMe: Flow is too dumb to realize that it is valid
-        clauseMap[type].push(cond)
-        break
       case 'take':
       case 'skip':
         // $FlowFixMe: Flow is too dumb to realize that it is valid
@@ -285,7 +278,13 @@ const extractClauses: (Clause[]) => QueryDescription = clauses => {
         break
       default:
       case 'where':
-        clauseMap.where.push(cond)
+        type = 'where'
+        // fallthrough
+      case 'on':
+        if (type === 'on') type = 'join'
+        // fallthrough
+      case 'sortBy':
+        clauseMap[type].push(cond)
         break
     }
   })

--- a/src/QueryDescription/test.js
+++ b/src/QueryDescription/test.js
@@ -513,7 +513,7 @@ describe('QueryDescription', () => {
   })
   it('supports sorting query', () => {
     const query = Q.buildQueryDescription([
-      Q.sortBy('sortable_column', 'desc'),
+      Q.sortBy('sortable_column', Q.desc),
     ])
     expect(query).toEqual({
       where: [],

--- a/src/QueryDescription/test.js
+++ b/src/QueryDescription/test.js
@@ -6,6 +6,9 @@ describe('QueryDescription', () => {
     expect(query).toEqual({
       where: [],
       join: [],
+      sortBy: [],
+      skip: null,
+      take: null,
     })
   })
   it('builds simple query', () => {
@@ -22,6 +25,9 @@ describe('QueryDescription', () => {
         },
       ],
       join: [],
+      sortBy: [],
+      skip: null,
+      take: null,
     })
   })
   it('accepts multiple conditions and value types', () => {
@@ -76,6 +82,9 @@ describe('QueryDescription', () => {
         },
       ],
       join: [],
+      sortBy: [],
+      skip: null,
+      take: null,
     })
   })
   it('supports multiple operators', () => {
@@ -193,6 +202,9 @@ describe('QueryDescription', () => {
         },
       ],
       join: [],
+      sortBy: [],
+      skip: null,
+      take: null,
     })
   })
   it('supports column comparisons', () => {
@@ -209,6 +221,9 @@ describe('QueryDescription', () => {
         },
       ],
       join: [],
+      sortBy: [],
+      skip: null,
+      take: null,
     })
   })
   it('supports AND/OR nesting', () => {
@@ -274,6 +289,9 @@ describe('QueryDescription', () => {
         },
       ],
       join: [],
+      sortBy: [],
+      skip: null,
+      take: null,
     })
   })
   it('supports simple JOIN queries', () => {
@@ -313,6 +331,9 @@ describe('QueryDescription', () => {
           },
         },
       ],
+      sortBy: [],
+      skip: null,
+      take: null,
     })
   })
   it('supports alternative `on` syntax', () => {
@@ -376,6 +397,9 @@ describe('QueryDescription', () => {
         },
       ],
       join: [],
+      sortBy: [],
+      take: null,
+      skip: null,
     })
   })
   it('builds simple query without deleted', () => {
@@ -402,6 +426,9 @@ describe('QueryDescription', () => {
         },
       ],
       join: [],
+      sortBy: [],
+      skip: null,
+      take: null,
     })
   })
   it('supports simple 2 JOIN queries on one table and JOIN query on another without deleted', () => {
@@ -479,6 +506,87 @@ describe('QueryDescription', () => {
           },
         },
       ],
+      sortBy: [],
+      skip: null,
+      take: null,
+    })
+  })
+  it('supports sorting query', () => {
+    const query = Q.buildQueryDescription([
+      Q.sortBy('sortable_column', 'desc'),
+    ])
+    expect(query).toEqual({
+      where: [],
+      join: [],
+      sortBy: [
+        {
+          type: 'sortBy',
+          sortColumn: 'sortable_column',
+          sortOrder: 'desc',
+        },
+      ],
+      skip: null,
+      take: null,
+    })
+  })
+  it('supports take operator', () => {
+    const query = Q.buildQueryDescription([
+      Q.take(100),
+    ])
+    expect(query).toEqual({
+      where: [],
+      join: [],
+      sortBy: [],
+      take: {
+        type: 'take',
+        count: 100,
+      },
+      skip: null,
+    })
+  })
+  it('does not support skip operator without take operator', () => {
+    expect(() => {
+      Q.buildQueryDescription([
+        Q.skip(100),
+      ])
+    }).toThrow('cannot skip without take')
+  })
+  it('supports multiple take operators and take the last', () => {
+    const query = Q.buildQueryDescription([
+      Q.take(100),
+      Q.take(200),
+      Q.take(400),
+    ])
+    expect(query).toEqual({
+      where: [],
+      join: [],
+      sortBy: [],
+      take: {
+        type: 'take',
+        count: 400,
+      },
+      skip: null,
+    })
+  })
+  it('support multiple skip operators but only take the last', () => {
+    const query = Q.buildQueryDescription([
+      Q.take(100),
+      Q.skip(200),
+      Q.skip(400),
+      Q.skip(800),
+    ])
+    expect(query).toEqual({
+      where: [],
+      join: [],
+      sortBy: [],
+      take: {
+        type: 'take',
+        count: 100,
+      },
+      skip: {
+        type: 'skip',
+        count: 800,
+      },
     })
   })
 })

--- a/src/QueryDescription/test.js
+++ b/src/QueryDescription/test.js
@@ -513,7 +513,7 @@ describe('QueryDescription', () => {
   })
   it('supports sorting query', () => {
     const query = Q.buildQueryDescription([
-      Q.sortBy('sortable_column', Q.desc),
+      Q.experimentalSortBy('sortable_column', Q.desc),
     ])
     expect(query).toEqual({
       where: [],
@@ -531,7 +531,7 @@ describe('QueryDescription', () => {
   })
   it('supports take operator', () => {
     const query = Q.buildQueryDescription([
-      Q.take(100),
+      Q.experimentalTake(100),
     ])
     expect(query).toEqual({
       where: [],
@@ -547,15 +547,15 @@ describe('QueryDescription', () => {
   it('does not support skip operator without take operator', () => {
     expect(() => {
       Q.buildQueryDescription([
-        Q.skip(100),
+        Q.experimentalSkip(100),
       ])
     }).toThrow('cannot skip without take')
   })
   it('supports multiple take operators and take the last', () => {
     const query = Q.buildQueryDescription([
-      Q.take(100),
-      Q.take(200),
-      Q.take(400),
+      Q.experimentalTake(100),
+      Q.experimentalTake(200),
+      Q.experimentalTake(400),
     ])
     expect(query).toEqual({
       where: [],
@@ -570,10 +570,10 @@ describe('QueryDescription', () => {
   })
   it('support multiple skip operators but only take the last', () => {
     const query = Q.buildQueryDescription([
-      Q.take(100),
-      Q.skip(200),
-      Q.skip(400),
-      Q.skip(800),
+      Q.experimentalTake(100),
+      Q.experimentalSkip(200),
+      Q.experimentalSkip(400),
+      Q.experimentalSkip(800),
     ])
     expect(query).toEqual({
       where: [],

--- a/src/adapters/lokijs/worker/encodeQuery/index.js
+++ b/src/adapters/lokijs/worker/encodeQuery/index.js
@@ -34,7 +34,7 @@ import type {
   Where,
   ComparisonRight,
   Comparison,
-  Condition,
+  Clause,
   CompoundValue,
 } from '../../../../QueryDescription'
 import { type TableName, type ColumnName, columnName } from '../../../../Schema'
@@ -149,13 +149,13 @@ const encodeWhereDescription: (WhereDescription | On) => LokiRawQuery = ({ left,
 
 const typeEq = propEq('type')
 
-const encodeCondition: Condition => LokiRawQuery = condition =>
+const encodeCondition: Clause => LokiRawQuery = clause =>
   (cond([
     [typeEq('and'), encodeAnd],
     [typeEq('or'), encodeOr],
     [typeEq('where'), encodeWhereDescription],
     [typeEq('on'), encodeWhereDescription],
-  ]): any)(condition)
+  ]): any)(clause)
 
 const encodeAndOr: LokiKeyword => (And | Or) => LokiRawQuery = op =>
   pipe(

--- a/src/adapters/sqlite/encodeQuery/index.js
+++ b/src/adapters/sqlite/encodeQuery/index.js
@@ -11,6 +11,9 @@ import type {
   On,
   And,
   Or,
+  SortBy,
+  Take,
+  Skip,
   QueryDescription,
 } from '../../../QueryDescription'
 import * as Q from '../../../QueryDescription'
@@ -151,7 +154,7 @@ const encodeAssociation: (TableName<any>) => AssociationArgs => string = mainTab
 const encodeJoin = (table: TableName<any>, associations: AssociationArgs[]): string =>
   associations.length ? associations.map(encodeAssociation(table)).join('') : ''
 
-const encodeOrderBy = (table: TableName<any>, sortBys) => {
+const encodeOrderBy = (table: TableName<any>, sortBys: SortBy[]) => {
   if (sortBys.length === 0) {
     return ''
   }
@@ -161,7 +164,7 @@ const encodeOrderBy = (table: TableName<any>, sortBys) => {
   return ` order by ${orderBys}`
 }
 
-const encodeLimitOffset = (take, skip) => {
+const encodeLimitOffset = (take: ?Take, skip: ?Skip) => {
   const limit = take?.count
   const offset = skip?.count
 

--- a/src/adapters/sqlite/encodeQuery/index.js
+++ b/src/adapters/sqlite/encodeQuery/index.js
@@ -1,6 +1,7 @@
 // @flow
 /* eslint-disable no-use-before-define */
 
+import invariant from '../../../utils/common/invariant'
 import type { SerializedQuery, AssociationArgs } from '../../../Query'
 import type {
   NonNullValues,
@@ -158,9 +159,13 @@ const encodeOrderBy = (table: TableName<any>, sortBys: SortBy[]) => {
   if (sortBys.length === 0) {
     return ''
   }
-  const orderBys = sortBys.map(sortBy =>
-    `${encodeName(table)}.${encodeName(sortBy.sortColumn)} ${sortBy.sortOrder}`
-  ).join(', ')
+  const orderBys = sortBys.map(sortBy => {
+    invariant(
+      ['asc', 'desc'].includes(sortBy.sortOrder),
+      `Invalid sortOrder argument "${sortBy.sortOrder}" received for Q.sortBy (valid: asc, desc)`,
+    )
+    return `${encodeName(table)}.${encodeName(sortBy.sortColumn)} ${sortBy.sortOrder}`
+  }).join(', ')
   return ` order by ${orderBys}`
 }
 

--- a/src/adapters/sqlite/encodeQuery/test.js
+++ b/src/adapters/sqlite/encodeQuery/test.js
@@ -119,6 +119,15 @@ describe('SQLite encodeQuery', () => {
       `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' order by "tasks"."sortable_column" desc`,
     )
   })
+  it('encodes multiple order by clauses', () => {
+    const query = new Query(mockCollection, [
+      Q.sortBy('sortable_column', Q.desc),
+      Q.sortBy('sortable_column2', Q.asc),
+    ])
+    expect(encodeQuery(query)).toBe(
+      `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' order by "tasks"."sortable_column" desc, "tasks"."sortable_column2" asc`,
+    )
+  })
   it('encodes limit clause', () => {
     const query = new Query(mockCollection, [
       Q.take(100),

--- a/src/adapters/sqlite/encodeQuery/test.js
+++ b/src/adapters/sqlite/encodeQuery/test.js
@@ -113,7 +113,7 @@ describe('SQLite encodeQuery', () => {
   })
   it('encodes order by clause', () => {
     const query = new Query(mockCollection, [
-      Q.sortBy('sortable_column', 'desc'),
+      Q.sortBy('sortable_column', Q.desc),
     ])
     expect(encodeQuery(query)).toBe(
       `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' order by "tasks"."sortable_column" desc`,

--- a/src/adapters/sqlite/encodeQuery/test.js
+++ b/src/adapters/sqlite/encodeQuery/test.js
@@ -21,7 +21,7 @@ describe('SQLite encodeQuery', () => {
       `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted'`,
     )
   })
-  it('encodes multiple onditions and value types', () => {
+  it('encodes multiple conditions and value types', () => {
     const query = new Query(mockCollection, [
       Q.where('col1', `value "'with'" quotes`),
       Q.where('col2', 2),
@@ -109,6 +109,41 @@ describe('SQLite encodeQuery', () => {
     ])
     expect(encodeQuery(query)).toBe(
       `select "tasks".* from "tasks" where "tasks"."col1" like '%abc' and "tasks"."col2" not like 'def%' and "tasks"."_status" is not 'deleted'`,
+    )
+  })
+  it('encodes order by clause', () => {
+    const query = new Query(mockCollection, [
+      Q.sortBy('sortable_column', 'desc'),
+    ])
+    expect(encodeQuery(query)).toBe(
+      `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' order by "tasks"."sortable_column" desc`,
+    )
+  })
+  it('encodes limit clause', () => {
+    const query = new Query(mockCollection, [
+      Q.take(100),
+    ])
+    expect(encodeQuery(query)).toBe(
+      `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' limit 100`,
+    )
+  })
+  it('encodes limit with offset clause', () => {
+    const query = new Query(mockCollection, [
+      Q.take(100),
+      Q.skip(200),
+    ])
+    expect(encodeQuery(query)).toBe(
+      `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' limit 100 offset 200`,
+    )
+  })
+  it('encodes order by together with limit and offset clause', () => {
+    const query = new Query(mockCollection, [
+      Q.sortBy('sortable_column', 'desc'),
+      Q.take(100),
+      Q.skip(200),
+    ])
+    expect(encodeQuery(query)).toBe(
+      `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' order by "tasks"."sortable_column" desc limit 100 offset 200`,
     )
   })
 })

--- a/src/adapters/sqlite/encodeQuery/test.js
+++ b/src/adapters/sqlite/encodeQuery/test.js
@@ -128,6 +128,12 @@ describe('SQLite encodeQuery', () => {
       `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' order by "tasks"."sortable_column" desc, "tasks"."sortable_column2" asc`,
     )
   })
+  it('throws an error if sortOrder received by sortBy is invalid', () => {
+    const query = new Query(mockCollection, [
+      Q.sortBy('sortable_column', 'aesc'),
+    ])
+    expect(() => encodeQuery(query)).toThrow('Invalid sortOrder argument "aesc" received for Q.sortBy (valid: asc, desc)')
+  })
   it('encodes limit clause', () => {
     const query = new Query(mockCollection, [
       Q.take(100),

--- a/src/adapters/sqlite/encodeQuery/test.js
+++ b/src/adapters/sqlite/encodeQuery/test.js
@@ -113,7 +113,7 @@ describe('SQLite encodeQuery', () => {
   })
   it('encodes order by clause', () => {
     const query = new Query(mockCollection, [
-      Q.sortBy('sortable_column', Q.desc),
+      Q.experimentalSortBy('sortable_column', Q.desc),
     ])
     expect(encodeQuery(query)).toBe(
       `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' order by "tasks"."sortable_column" desc`,
@@ -121,22 +121,22 @@ describe('SQLite encodeQuery', () => {
   })
   it('encodes multiple order by clauses', () => {
     const query = new Query(mockCollection, [
-      Q.sortBy('sortable_column', Q.desc),
-      Q.sortBy('sortable_column2', Q.asc),
+      Q.experimentalSortBy('sortable_column', Q.desc),
+      Q.experimentalSortBy('sortable_column2', Q.asc),
     ])
     expect(encodeQuery(query)).toBe(
       `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' order by "tasks"."sortable_column" desc, "tasks"."sortable_column2" asc`,
     )
   })
-  it('throws an error if sortOrder received by sortBy is invalid', () => {
+  it('throws an error if sortOrder received sortBy is invalid', () => {
     const query = new Query(mockCollection, [
-      Q.sortBy('sortable_column', 'aesc'),
+      Q.experimentalSortBy('sortable_column', 'aesc'),
     ])
     expect(() => encodeQuery(query)).toThrow('Invalid sortOrder argument "aesc" received for Q.sortBy (valid: asc, desc)')
   })
   it('encodes limit clause', () => {
     const query = new Query(mockCollection, [
-      Q.take(100),
+      Q.experimentalTake(100),
     ])
     expect(encodeQuery(query)).toBe(
       `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' limit 100`,
@@ -144,8 +144,8 @@ describe('SQLite encodeQuery', () => {
   })
   it('encodes limit with offset clause', () => {
     const query = new Query(mockCollection, [
-      Q.take(100),
-      Q.skip(200),
+      Q.experimentalTake(100),
+      Q.experimentalSkip(200),
     ])
     expect(encodeQuery(query)).toBe(
       `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' limit 100 offset 200`,
@@ -153,9 +153,9 @@ describe('SQLite encodeQuery', () => {
   })
   it('encodes order by together with limit and offset clause', () => {
     const query = new Query(mockCollection, [
-      Q.sortBy('sortable_column', 'desc'),
-      Q.take(100),
-      Q.skip(200),
+      Q.experimentalSortBy('sortable_column', 'desc'),
+      Q.experimentalTake(100),
+      Q.experimentalSkip(200),
     ])
     expect(encodeQuery(query)).toBe(
       `select "tasks".* from "tasks" where "tasks"."_status" is not 'deleted' order by "tasks"."sortable_column" desc limit 100 offset 200`,

--- a/src/sync/impl/applyRemote.js
+++ b/src/sync/impl/applyRemote.js
@@ -167,8 +167,8 @@ const getAllRecordsToApply = (
       const collection = db.collections.get((tableName: any))
 
       if (!collection) {
-        return Promise.reject(`You are trying to sync a collection named ${tableName}, but currently this collection does not exist.` + 
-        `Have you remembered to add it to your Database constructor\'s modelClasses property?`)
+        return Promise.reject(new Error(`You are trying to sync a collection named ${tableName}, but currently this collection does not exist.` + 
+        `Have you remembered to add it to your Database constructor\'s modelClasses property?`))
       }
       
       return recordsToApplyRemoteChangesTo(collection, changes)


### PR DESCRIPTION
Added experimental `Q.sortBy(sortColumn, sortOrder)`, `Q.take(count)`, `Q.skip(count)` methods
Add support for `sortBy`, `take` and  `skip` operators into Sqlite adapter