### PR TITLE
replace the sql parser on android to fixed a potential crash

### DIFF
--- a/native/android/build.gradle
+++ b/native/android/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.github.xelven:SqlParser-Android:1.0'
 }
 repositories {
     mavenCentral()

--- a/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
@@ -3,6 +3,7 @@ package com.nozbe.watermelondb
 import android.content.Context
 import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
+import org.xelven.sqlparser.SQLParser
 import java.io.File
 
 class Database(private val name: String, private val context: Context) {
@@ -27,8 +28,11 @@ class Database(private val name: String, private val context: Context) {
 
     fun executeStatements(statements: SQL) =
             transaction {
-                statements.split(";").forEach {
-                    if (it.isNotBlank()) execute(it)
+                var parser = SQLParser()
+                parser.setUseScriptDetecting(true)
+                parser.parseScript(statements)
+                parser.getStatements().forEach {
+                    if (it.sql.isNotBlank()) execute(it.sql)
                 }
             }
 


### PR DESCRIPTION
replace the sql parser from string to fixed a crash issue when it try to parser a mass sql script string if it contian a grammar such as 'create trigger' with double ';'

currently is parser sql with ";" is too bad, so I create my own sql parser base on protocol: http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt


otherwise it will 100% crash when run :
`create trigger "aaas_fts_delete" after delete on "aaas" begin delete from "aaas_fts" where "rowid" = OLD.rowid; end;`