### PR TITLE
Fix typescript type of changes key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - [Typescript] Fixed types of decorators.
 - [Typescript] Add Tests to test Types.
 - Fixed typo in learn-to-use docs.
+- [Typescript] Fixed types of changes.
 
 ## 0.16 - 2020-03-06
 

--- a/src/Collection/index.d.ts
+++ b/src/Collection/index.d.ts
@@ -9,12 +9,14 @@ declare module '@nozbe/watermelondb/Collection' {
     isDestroyed: boolean
   }
 
+  export type CollectionChangeSet<Record extends Model> = CollectionChange<Record>[]
+
   export default class Collection<Record extends Model> {
     public database: Database
 
     public modelClass: Class<Record>
 
-    public changes: Subject<CollectionChange<Record>>
+    public changes: Subject<CollectionChangeSet<Record>>
 
     public table: TableName<Record>
 

--- a/src/Database/index.d.ts
+++ b/src/Database/index.d.ts
@@ -1,6 +1,6 @@
 declare module '@nozbe/watermelondb/Database' {
   import { AppSchema, CollectionMap, DatabaseAdapter, Model, TableName } from '@nozbe/watermelondb'
-  import { CollectionChange } from '@nozbe/watermelondb/Collection'
+  import { CollectionChangeSet } from '@nozbe/watermelondb/Collection'
   import { Class } from '@nozbe/watermelondb/utils/common'
   import { Observable } from 'rxjs'
 
@@ -29,7 +29,7 @@ declare module '@nozbe/watermelondb/Database' {
 
     public withChangesForTables(
       tables: Array<TableName<any>>,
-    ): Observable<CollectionChange<any> | null>
+    ): Observable<CollectionChangeSet<any> | null>
 
     public unsafeResetDatabase(): Promise<void>
   }


### PR DESCRIPTION
Inside of js:
```
export type CollectionChange<Record: Model> = { record: Record, type: CollectionChangeType }
export type CollectionChangeSet<T> = CollectionChange<T>[]
...
 changes: Subject<CollectionChangeSet<Record>> = new Subject()
```

**Typescript type should be also an array of `CollectionChange` and not just one `CollectionChange`**