### PR TITLE
Sync.md: add tutorial how to build sync backend

### DIFF
--- a/docs-master/Advanced/Sync.md
+++ b/docs-master/Advanced/Sync.md
@@ -188,6 +188,7 @@ Synchronization is serious business! It's very easy to make mistakes that will c
 Note that those are not maintained by WatermelonDB, and we make no endorsements about quality of these projects:
 
 - https://github.com/AliAllaf/firemelon
+- https://fahri.id/posts/how-to-build-watermelondb-sync-backend-in-elixir/ (tutorial)
 - Did you make one? Please contribute a link!
 
 ### Current limitations


### PR DESCRIPTION
I've  published a post how to build WatermelonDB sync backend in Elixir.
It may provides a starting point for others  to build their own backend.
Feedback is welcome.