### PR TITLE
[ios] Add the path to the jsi headers - issue #691

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Fixes
 
 - [iOS] Fixed a bug that could cause a database operation to fail with an (6) SQLITE_LOCKED error
+- [iOS] Fixed 'jsi/jsi.h' file not found when building at the consumer level. (issue #691)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Fixes
 
 - [iOS] Fixed a bug that could cause a database operation to fail with an (6) SQLITE_LOCKED error
-- [iOS] Fixed 'jsi/jsi.h' file not found when building at the consumer level. (issue #691)
+- [iOS] Fixed 'jsi/jsi.h' file not found when building at the consumer level. Added path `$(SRCROOT)/../../../../../ios/Pods/Headers/Public/React-jsi` to Header Search Paths (issue #691)
 
 ### Internal
 

--- a/native/ios/WatermelonDB.xcodeproj/project.pbxproj
+++ b/native/ios/WatermelonDB.xcodeproj/project.pbxproj
@@ -390,6 +390,7 @@
 					"$(SRCROOT)/../../../../node_modules/react-native/Libraries/**",
 					"$(SRCROOT)/../../../../../ios/Pods/Headers/Public/React-Core/**",
 					"$(SRCROOT)/../../../../../../native/ios/Pods/Headers/Public/React-Core",
+					"$(SRCROOT)/../../../../../ios/Pods/Headers/Public/React-jsi/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -442,6 +443,7 @@
 					"$(SRCROOT)/../../../../node_modules/react-native/Libraries/**",
 					"$(SRCROOT)/../../../../../ios/Pods/Headers/Public/React-Core/**",
 					"$(SRCROOT)/../../../../../../native/ios/Pods/Headers/Public/React-Core",
+					"$(SRCROOT)/../../../../../ios/Pods/Headers/Public/React-jsi/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
I added a Header Search Path that contained the JSI headers that the compiler was complaining about.

There is another set of JSI headers inside `react-native/ReactCommon` that seems more appropriate, but other issues came up after added those.

https://github.com/Nozbe/WatermelonDB/issues/691

Please merge if you see fit, or deny if there's a better way to include these headers. I have no idea why they're not present anymore in the header search paths included. Maybe JSI was moved in React Native?