### PR TITLE
Fix crashes if the query has undefined as value

### DIFF
--- a/src/observation/encodeMatcher/index.js
+++ b/src/observation/encodeMatcher/index.js
@@ -30,7 +30,7 @@ const encodeWhereDescription: WhereDescription => Matcher<*> = description => ra
   } else if (compRight.column) {
     right = (rawRecord: Object)[compRight.column]
   } else {
-    throw new Error('Invalid comparisonRight')
+    right = undefined
   }
 
   return operator(left, right)


### PR DESCRIPTION
Hi!

For example, I have lines like these
```
const enhance = withObservables(['noteId'], ({ noteId }) => ({
  images: database.collections.get('note_images').query(Q.where('note_id', noteId)),
}));
```

`noteId` may be `undefined` at some points in time. I understand that this is bad and I fixed it, but in this case I get an unpleasant crash.
Fetching from the database itself works well with `undefined`, but when you change any record in this table, the application dies. The action is in one place, but the error is thrown from another place. This moment is hard to find and debug.
Therefore, I propose to do the same behavior for the fetch and for observe, removing the throwing error.
For example, in the sqlite adapter, `undefined` is set to null. And on observe, undefined == null // => true
