### PR TITLE
Database._write/_read/_together

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -6,8 +6,8 @@
 
 ### New features
 
-- [Android] `exerimentalUseJSI` option has been enabled on Android
 - [iOS] Added CocoaPods support - @leninlin
+- [Android] `exerimentalUseJSI` option has been enabled on Android. However, it requires some app-specific setup which is not yet documented - stay tuned for upcoming releases
 - [Schema] [Migrations] You can now pass `unsafeSql` parameters to schema builder and migration steps to modify SQL generated to set up the database or perform migrations. There's also new `unsafeExecuteSql` migration step. Please use this only if you know what you're doing — you shouldn't need this in 99% of cases. See Schema and Migrations docs for more details
 
 ### Changes

--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -150,6 +150,19 @@ export default class Database {
     return this._actionQueue.enqueue(work, description)
   }
 
+  /* EXPERIMENTAL API - DO NOT USE */
+  _write<T>(work: ActionInterface => Promise<T>, description?: string): Promise<T> {
+    return this._actionQueue.enqueue(work, description)
+  }
+
+  _read<T>(work: ActionInterface => Promise<T>, description?: string): Promise<T> {
+    return this._actionQueue.enqueue(work, description)
+  }
+
+  _together<T>(work: ActionInterface => Promise<T>, description?: string): Promise<T> {
+    return this._actionQueue.enqueue(work, description)
+  }
+
   // Emits a signal immediately, and on change in any of the passed tables
   withChangesForTables(tables: TableName<any>[]): Observable<CollectionChangeSet<any> | null> {
     const changesSignals = tables.map(table => this.collections.get(table).changes)


### PR DESCRIPTION
‼️ dependent branch

okay, so this is a tiny one, but I want to explain to you where I'm going with this.

`database.action(() => {}` is confusing, isn't it? It doesn't feel right calling it "action", and it sure as hell confuses open source users. What it really is an exclusive lock. But calling it that wouldn't help with confusion to most people.

So how about calling it `database.write(() => {})` ? That would fit the main purpose, since all write operations must be wrapped in what we now call an action. You do `db.write(() => and make write operations here)`. It's also very similar to how Realm deals with it.

But again, this is an exclusive lock and you also can (and should) use it to do multiple reads which depend on each other (as in, they must maintain consistent view of the database). But wow, is `database.action(() => just reads here)` confusing. So we can have `db.read(() => consistent reads here)`. This has another advantage. `action()` is a RW lock, but while we must not allow multiple concurrent write operations, or both write and read operations, we can allow multiple concurrent reader blocks, since without a running writer block, we have a guarantee of a consistent view. And one more. Write methods check if there's a running action to detect incorrect use. But reader blocks could set a different flag, so if someone tried to batch in a reader block, that would fail - discovering more bugs.

One more API idea is to call it "db.together(() => { ... })`, since it guarantees that whetever's inside is done together, without any other write actions messing up the consistency.

Anyway, I want to experiment with that in NT to see if this API feels right, so I'm not documenting it or making any functional changes, just adding underscore-prefixed so we can play with it