### PR TITLE
Add cassert dependency to Sqlite.cpp

### DIFF
--- a/native/shared/Sqlite.cpp
+++ b/native/shared/Sqlite.cpp
@@ -1,5 +1,6 @@
 #include "Sqlite.h"
 #include "DatabasePlatform.h"
+#include <cassert>
 
 namespace watermelondb {
 


### PR DESCRIPTION
After updating to the latest version of watermelondb, our builds started failing with `Use of undeclared identifier 'assert'` errors coming back to this file. 

We are pretty light on native code, so we hadn't included it elsewhere in our project, we should include the dependency explicitly here.

After adding this line, the build worked properly and our app ran as expected