### PR TITLE
Allowing LokiJS autosave to be configured

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -11,6 +11,7 @@
 ### Changes
 
 ｰ [Android] Support Autolinking. Above RN 0.60.x, [Android Installation steps](https://nozbe.github.io/WatermelonDB/Installation.html#android-react-native) is no longer needed expect Babel, Kotlin, and Troubleshooting steps.
+- [LokiJS] Adapter autosave option is now configurable
 
 ### Fixes
 

--- a/src/adapters/lokijs/index.d.ts
+++ b/src/adapters/lokijs/index.d.ts
@@ -18,6 +18,7 @@ declare module '@nozbe/watermelondb/adapters/lokijs' {
 
   export interface LokiAdapterOptions {
     dbName?: string
+    autosave?: boolean
     schema: AppSchema
     migrations?: SchemaMigrations
     _testLokiAdapter?: LokiMemoryAdapter,

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -36,6 +36,7 @@ type LokiIDBSerializer = $Exact<{
 
 export type LokiAdapterOptions = $Exact<{
   dbName?: ?string,
+  autosave?: boolean,
   schema: AppSchema,
   migrations?: SchemaMigrations,
   // (true by default) Although web workers may have some throughput benefits, disabling them

--- a/src/adapters/lokijs/worker/lokiExtensions.js
+++ b/src/adapters/lokijs/worker/lokiExtensions.js
@@ -73,9 +73,10 @@ async function getLokiAdapter(options: LokiAdapterOptions): mixed {
 }
 
 export async function newLoki(options: LokiAdapterOptions): Loki {
+  const { autosave = true } = options
   const loki = new Loki(options.dbName, {
     adapter: await getLokiAdapter(options),
-    autosave: true,
+    autosave,
     autosaveInterval: 250,
     verbose: true,
   })


### PR DESCRIPTION
The LokiJS autosave feature is initiating an infinite loop during jest tests when running `jest.runAllTimers()`.

Allowing it to be configured so that it can be disabled when mocking out the adapter.