### PR TITLE
Add android autolinking config on react-native.config.js

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -10,6 +10,8 @@
 
 ### Changes
 
+ｰ [Android] Support Autolinking. Above RN 0.60.x, [Android Installation steps](https://nozbe.github.io/WatermelonDB/Installation.html#android-react-native) is no longer needed expect Babel, Kotlin, and Troubleshooting steps.
+
 ### Fixes
 
 ### Internal

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        sourceDir: './native/android',
+      },
+    },
+  },
+};


### PR DESCRIPTION
On Android, Autolining is not working properly Due to android config is null.

```
~/g/RNSandbox63 ❯❯❯ yarn --silent react-native config | jq '.dependencies."@nozbe/watermelondb"'
{
  "root": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb",
  "name": "@nozbe/watermelondb",
  "platforms": {
    "ios": {
      "sourceDir": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb/native/ios",
      "folder": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb",
      "pbxprojPath": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb/native/ios/WatermelonDB.xcodeproj/project.pbxproj",
      "podfile": null,
      "podspecPath": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb/WatermelonDB.podspec",
      "projectPath": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb/native/ios/WatermelonDB.xcodeproj",
      "projectName": "WatermelonDB.xcodeproj",
      "libraryFolder": "Libraries",
      "sharedLibraries": [],
      "plist": [],
      "scriptPhases": []
    },
    "android": null
  },
  "assets": [],
  "hooks": {},
  "params": []
}

```

So, adding Android config to working properly.

```
~/g/RNSandbox63 ❯❯❯ yarn --silent react-native config | jq '.dependencies."@nozbe/watermelondb"'
{
  "root": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb",
  "name": "@nozbe/watermelondb",
  "platforms": {
    "ios": {
      "sourceDir": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb/native/ios",
      "folder": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb",
      "pbxprojPath": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb/native/ios/WatermelonDB.xcodeproj/project.pbxproj",
      "podfile": null,
      "podspecPath": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb/WatermelonDB.podspec",
      "projectPath": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb/native/ios/WatermelonDB.xcodeproj",
      "projectName": "WatermelonDB.xcodeproj",
      "libraryFolder": "Libraries",
      "sharedLibraries": [],
      "plist": [],
      "scriptPhases": []
    },
    "android": {
      "sourceDir": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb/native/android",
      "folder": "/Users/keima/git/RNSandbox63/node_modules/@nozbe/watermelondb",
      "packageImportPath": "import com.nozbe.watermelondb.WatermelonDBPackage;",
      "packageInstance": "new WatermelonDBPackage()"
    }
  },
  "assets": [],
  "hooks": {},
  "params": []
}
```

React Native (Native Modules) is not support Kotlin officially.
So setup Kotlin step is required yet.
