### PR TITLE
[FIX] Get date as instance of Date

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -15,5 +15,6 @@
 
 ### Fixes
 - Fixed warn "import cycle" from DialogProvider (#786) by @gmonte.
+- Fixed cache date as instance of Date (#828) by @djorkaeffalexandre.
 
 ### Internal

--- a/src/decorators/date/index.js
+++ b/src/decorators/date/index.js
@@ -42,7 +42,7 @@ const dateDecorator = makeDecorator(
       set(date: ?Date): void {
         const rawValue = date ? +new Date(date) : null
         if (rawValue && date) {
-          cache.set(rawValue, date)
+          cache.set(rawValue, new Date(date))
         }
         this.asModel._setRaw(columnName, rawValue)
       },

--- a/src/decorators/date/test.js
+++ b/src/decorators/date/test.js
@@ -60,9 +60,9 @@ describe('decorators/timestamp', () => {
   })
   it('returns a instance of date if cached', () => {
     const model = new MockModel({ schema }, { date: 0 })
-    // No cached
     expect(model.date).toBeInstanceOf(Date)
-    // Cached
+    model._isEditing = true
+    model.date = '2011-10-05T14:48:00.000Z'
     expect(model.date).toBeInstanceOf(Date)
   })
 })

--- a/src/decorators/date/test.js
+++ b/src/decorators/date/test.js
@@ -58,4 +58,11 @@ describe('decorators/timestamp', () => {
         },
     ).toThrow(/column name/)
   })
+  it('returns a instance of date if cached', () => {
+    const model = new MockModel({ schema }, { date: 0 })
+    // No cached
+    expect(model.date).toBeInstanceOf(Date)
+    // Cached
+    expect(model.date).toBeInstanceOf(Date)
+  })
 })


### PR DESCRIPTION
When a date is cached, it's returning as a string instead of a Date instance.