### PR TITLE
fix type of OnFunction to accept Q.and and Q.or

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -12,4 +12,6 @@
 
 ### Fixes
 
+- [Typescript] Fixed type on OnFunction to accept `and` in join 
+
 ### Internal

--- a/src/QueryDescription/index.d.ts
+++ b/src/QueryDescription/index.d.ts
@@ -108,7 +108,7 @@ declare module '@nozbe/watermelondb/QueryDescription' {
     column: ColumnName,
     comparison: Comparison,
   ) => On
-  type _OnFunctionWhereDescription = (table: TableName<any>, where: WhereDescription) => On
+  type _OnFunctionWhereDescription = (table: TableName<any>, where: Where) => On
 
   type OnFunction = _OnFunctionColumnValue &
     _OnFunctionColumnComparison &


### PR DESCRIPTION
I need to use `Q.and` in Q.on 

```
 Q.on( 'projectDocument_folders', Q.and(Q.where('folder_type', Q.eq('plan')), Q.where('project_id', Q.eq(project.id))),),
```

Only `Q.where` is accepted according to defined types 