### PR TITLE
Pointing podspec to WatermelonDB repo

### DIFF
--- a/WatermelonDB.podspec
+++ b/WatermelonDB.podspec
@@ -1,6 +1,6 @@
 require "json"
 
-package = JSON.parse(File.read("package.json"))
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name         = "WatermelonDB"
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = package["licence"]
   s.author       = { "author" => package["author"] }
   s.platforms    = { :ios => "9.0", :tvos => "9.0" }
-  s.source       = { :http => 'file:' + __dir__ + '/'  }
+  s.source = { :git => "https://github.com/Nozbe/WatermelonDB.git", :tag => "v#{s.version}" }
   s.source_files = "native/ios/**/*.{h,m,mm,swift,c,cpp}", "native/shared/*.{h,c,cpp}"
   s.public_header_files = '**/Bridging.h'
   s.requires_arc = true


### PR DESCRIPTION
Per https://github.com/Nozbe/WatermelonDB/issues/851

`WatermelonDB.podspec` lists its source as `__dir__` which can create different checksums in the `Podfile.lock` for different members of a team working on the same project. Pointing the source to this repo instead and updating the package `File.read` call to match other podspecs that I'm seeing (React, RN Camera, RN Biometrics, etc..)