### PR TITLE
Return record in update method on Model.

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -5,6 +5,7 @@
 ### BREAKING CHANGES
 
 ### New features
+- [Model] `Model.update` method now returns updated record
 
 ### Performance
 

--- a/src/Model/index.d.ts
+++ b/src/Model/index.d.ts
@@ -35,7 +35,7 @@ declare module '@nozbe/watermelondb/Model' {
 
     public syncStatus: SyncStatus
 
-    public update(recordUpdater?: (record: this) => void): Promise<void>
+    public update(recordUpdater?: (record: this) => void): Promise<this>
 
     public prepareUpdate(recordUpdater?: (record: this) => void): this
 

--- a/src/Model/index.js
+++ b/src/Model/index.js
@@ -79,7 +79,7 @@ export default class Model {
   // someTask.update(task => {
   //   task.name = 'New name'
   // })
-  async update(recordUpdater: this => void = noop): Promise<void> {
+  async update(recordUpdater: this => void = noop): Promise<this> {
     this.collection.database._ensureInAction(
       `Model.update() can only be called from inside of an Action. See docs for more details.`,
     )

--- a/src/Model/index.js
+++ b/src/Model/index.js
@@ -83,8 +83,9 @@ export default class Model {
     this.collection.database._ensureInAction(
       `Model.update() can only be called from inside of an Action. See docs for more details.`,
     )
-    this.prepareUpdate(recordUpdater)
+    const record = this.prepareUpdate(recordUpdater)
     await this.collection.database.batch(this)
+    return record
   }
 
   // Prepares an update to the database (using passed function).

--- a/src/Model/test.js
+++ b/src/Model/test.js
@@ -182,7 +182,7 @@ describe('CRUD', () => {
 
     expect(m1._isEditing).toBe(false)
 
-    await m1.update(record => {
+    const update = await m1.update(record => {
       expect(m1._isEditing).toBe(true)
       record.name = 'New name'
     })
@@ -190,6 +190,7 @@ describe('CRUD', () => {
     expect(spyBatchDB).toHaveBeenCalledWith(m1)
     expect(spyOnPrepareUpdate).toHaveBeenCalledTimes(1)
     expect(observer).toHaveBeenCalledTimes(2)
+    expect(update).toBe(m1)
 
     expect(m1.name).toBe('New name')
     expect(m1.updatedAt).toBe(undefined)


### PR DESCRIPTION
This PR changes behavior of `update` to be consistent with the `Collection.create` method where it returns the record. I did this because it would be useful to get back record after update, to further manipulations like invoking subactions etc...