### PR TITLE
Add missing typescript LokiAdapterOptions fields

### DIFF
--- a/src/adapters/lokijs/index.d.ts
+++ b/src/adapters/lokijs/index.d.ts
@@ -21,7 +21,9 @@ declare module '@nozbe/watermelondb/adapters/lokijs' {
     autosave?: boolean
     schema: AppSchema
     migrations?: SchemaMigrations
-    _testLokiAdapter?: LokiMemoryAdapter,
+    useWebWorker?: boolean
+    useIncrementalIndexedDB?: boolean
+    _testLokiAdapter?: LokiMemoryAdapter
   }
 
   export default class LokiJSAdapter implements DatabaseAdapter {


### PR DESCRIPTION
Add useWebWorker and useIncrementalIndexedDB fields referenced in the [tutorial](https://nozbe.github.io/WatermelonDB/Installation.html#set-up-database)