### PR TITLE
Fix database#batch(records) types

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -14,5 +14,6 @@
 ### Fixes
 
 - [Typescript] Fixed type on OnFunction to accept `and` in join 
+- [Typescript] Fixed type `database#batch(records)`'s argument `records` to accept mixed types
 
 ### Internal

--- a/src/Database/index.d.ts
+++ b/src/Database/index.d.ts
@@ -22,7 +22,7 @@ declare module '@nozbe/watermelondb/Database' {
         actionsEnabled: boolean;
       })
 
-    public batch(...records: Model[] | null[] | void[] | false[] | Promise<void>[]): Promise<void>
+    public batch(...records: (Model | null | void | false | Promise<void>)[]): Promise<void>
 
     // TODO: action<T>(work: ActionInterface => Promise<T>, description?: string): Promise<T>
     public action<T>(work: any, description?: string): Promise<T>


### PR DESCRIPTION
In [Batch Updates section of WatermelonDB documentation](https://nozbe.github.io/WatermelonDB/Actions.html#batch-updates),

> You can pass falsy values (null, undefined, false) to batch — they will simply be ignored.

But below code written in TypeScript causes type error on latest version:

```
database.batch(user, null, false, undefined)
```

> TS2345: Argument of type '[User, null, false, undefined]' is not assignable to parameter of type 'Model[] | null[] | void[] | false[] | Promise<void>[]'.   Type '[User, null, false, undefined]' is not assignable to type 'Promise<void>[]'.     Type 'false | User | null | undefined' is not assignable to type 'Promise<void>'.       Type 'undefined' is not assignable to type 'Promise<void>'.

(note: `User` is database model)


This patch fixes above error.