### PR TITLE
Add react-native.config.js to npm packages

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -6,6 +6,7 @@
 
 ### New features
 - [Model] `Model.update` method now returns updated record
+- [Android] Autolinking is now supported (v0.20 is insufficient)
 
 ### Performance
 

--- a/scripts/make.js
+++ b/scripts/make.js
@@ -121,6 +121,7 @@ const copyNonJavaScriptFiles = buildPath => {
     'README.md',
     'yarn.lock',
     'WatermelonDB.podspec',
+    'react-native.config.js',
     'docs',
     'native/shared',
     'native/ios',


### PR DESCRIPTION
Previously, I implemented Autolinking on Android.

- https://github.com/Nozbe/WatermelonDB/pull/805

But I forgot to packaging `react-native.config.js`.
So v0.20 is NOT supported Autolinking on Android.

This patch fixes this problem (may be... I not yet familiar with Watermelon build system.).