### PR TITLE
🏷 Add Missing Props for SQLiteAdapterOptions

### DIFF
--- a/src/adapters/sqlite/index.d.ts
+++ b/src/adapters/sqlite/index.d.ts
@@ -24,6 +24,8 @@ declare module '@nozbe/watermelondb/adapters/sqlite' {
     dbName?: string
     migrations?: SchemaMigrations
     schema: AppSchema
+    synchronous?: boolean
+    experimentalUseJSI?: boolean
   }
 
   export default class SQLiteAdapter implements DatabaseAdapter {


### PR DESCRIPTION
TS error with web installation 
```
// First, create the adapter to the underlying database:
const adapter = new SQLiteAdapter({
  schema,
  // dbName: 'myapp', // optional database name or file system path
  // migrations, // optional migrations
  synchronous: true, // synchronous mode only works on iOS. improves performance and reduces glitches in most cases, but also has some downsides - test with and without it
  // experimentalUseJSI: true, // experimental JSI mode, use only if you're brave
})
```