### PR TITLE
🏷 add type to avoid TS error on sync file

### DIFF
--- a/src/sync/index.d.ts
+++ b/src/sync/index.d.ts
@@ -1,5 +1,7 @@
 declare module '@nozbe/watermelondb/sync' {
   import { DirtyRaw, RecordId, TableName, Model, Database } from '@nozbe/watermelondb';
+  import { Migration } from '@nozbe/watermelondb/Schema/migrations';
+  
   export type Timestamp = number
 
   export type SyncTableChangeSet = {
@@ -11,7 +13,7 @@ declare module '@nozbe/watermelondb/sync' {
 
   export type SyncLocalChanges = { changes: SyncDatabaseChangeSet, affectedRecords: Model[] }
 
-  export type SyncPullArgs = { lastPulledAt: Timestamp | null }
+  export type SyncPullArgs = { lastPulledAt: Timestamp | null, schemaVersion?: number, migration?: Migration | null }
   export type SyncPullResult = { changes: SyncDatabaseChangeSet, timestamp: Timestamp }
 
   export type SyncPushArgs = { changes: SyncDatabaseChangeSet, lastPulledAt: Timestamp }
@@ -32,6 +34,7 @@ declare module '@nozbe/watermelondb/sync' {
     sendCreatedAsUpdated?: boolean,
     log?: SyncLog,
     _unsafeBatchPerCollection?: boolean, // commits changes in multiple batches, and not one - temporary workaround for memory issue
+    migrationsEnabledAtVersion?: number
   }
 
   export function synchronize({


### PR DESCRIPTION
Avoir error in pullChanges props and synchronize props
```
export default async function mySync() {
  await synchronize({
    database,
    pullChanges: async ({ lastPulledAt, schemaVersion, migration }) => {
      const response = await fetch('https://my.backend/sync', {
        body: JSON.stringify({ lastPulledAt, schemaVersion, migration })
      })
      if (!response.ok) {
        throw new Error(await response.text())
      }

      const { changes, timestamp } = await response.json()
      return { changes, timestamp }
    },
    pushChanges: async ({ changes, lastPulledAt }) => {
      const response = await fetch(`https://my.backend/sync?last_pulled_at=${lastPulledAt}`, {
        method: 'POST',
        body: JSON.stringify(changes)
      })
      if (!response.ok) {
        throw new Error(await response.text())
      }
    },
    migrationsEnabledAtVersion: 1,
  })
}
```