### PR TITLE
[Typescript] Add definition for experimentalNestedJoin

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -19,7 +19,7 @@
 - [Sync] Open-sourced a simple SyncLogger you can optionally use. See docs for more info.
 - [SQLiteAdapter] `synchronous:true` option is now deprecated and will be replaced with `experimentalUseJSI: true` in the future. Please test if your app compiles and works well with `experimentalUseJSI: true`, and if not - file an issue!
 - [LokiJS] Changed default autosave interval from 250 to 500ms
-- [Typescript] Add `experimentalNestedJoin` definition
+- [Typescript] Add `experimentalNestedJoin` definition and `unsafeSqlExpr` clause
 
 ### Fixes
 

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -19,6 +19,7 @@
 - [Sync] Open-sourced a simple SyncLogger you can optionally use. See docs for more info.
 - [SQLiteAdapter] `synchronous:true` option is now deprecated and will be replaced with `experimentalUseJSI: true` in the future. Please test if your app compiles and works well with `experimentalUseJSI: true`, and if not - file an issue!
 - [LokiJS] Changed default autosave interval from 250 to 500ms
+- [Typescript] Add `experimentalNestedJoin` definition
 
 ### Fixes
 

--- a/src/QueryDescription/index.d.ts
+++ b/src/QueryDescription/index.d.ts
@@ -69,7 +69,12 @@ declare module '@nozbe/watermelondb/QueryDescription' {
     type: 'joinTables'
     tables: TableName<any>[]
   }
-  export type Clause = Where | On | SortBy | Take | Skip | Join
+  export interface NestedJoin {
+    type: 'nestedJoinTable'
+    from: TableName<any>
+    to: TableName<any>
+  }
+  export type Clause = Where | On | SortBy | Take | Skip | Join | NestedJoin
   export interface QueryDescription {
     where: Where[]
     join: On[]
@@ -77,6 +82,7 @@ declare module '@nozbe/watermelondb/QueryDescription' {
     take?: Take
     skip?: Skip
     joinTables?: Join
+    nestedJoinTables?: NestedJoin
   }
   export type Condition = Where | On
 
@@ -100,6 +106,7 @@ declare module '@nozbe/watermelondb/QueryDescription' {
   export function experimentalTake(count: number): Take
   export function experimentalSkip(count: number): Skip
   export function experimentalJoinTables(tables: TableName<any>[]): Join
+  export function experimentalNestedJoin(from: TableName<any>, to: TableName<any>): NestedJoin
   export function sanitizeLikeString(value: string): string
 
   type _OnFunctionColumnValue = (table: TableName<any>, column: ColumnName, value: Value) => On
@@ -109,10 +116,12 @@ declare module '@nozbe/watermelondb/QueryDescription' {
     comparison: Comparison,
   ) => On
   type _OnFunctionWhereDescription = (table: TableName<any>, where: Where) => On
+  type _OnFunctionNested = (table: TableName<any>, on: On) => On
 
   type OnFunction = _OnFunctionColumnValue &
     _OnFunctionColumnComparison &
-    _OnFunctionWhereDescription
+    _OnFunctionWhereDescription &
+    _OnFunctionNested
 
   export const on: OnFunction
 

--- a/src/QueryDescription/index.d.ts
+++ b/src/QueryDescription/index.d.ts
@@ -74,7 +74,12 @@ declare module '@nozbe/watermelondb/QueryDescription' {
     from: TableName<any>
     to: TableName<any>
   }
-  export type Clause = Where | On | SortBy | Take | Skip | Join | NestedJoin
+  export interface Sql {
+    type: 'sql'
+    expr: string
+  }
+
+  export type Clause = Where | On | SortBy | Take | Skip | Join | NestedJoin | Sql
   export interface QueryDescription {
     where: Where[]
     join: On[]
@@ -108,6 +113,7 @@ declare module '@nozbe/watermelondb/QueryDescription' {
   export function experimentalJoinTables(tables: TableName<any>[]): Join
   export function experimentalNestedJoin(from: TableName<any>, to: TableName<any>): NestedJoin
   export function sanitizeLikeString(value: string): string
+  export function unsafeSqlExpr(sql: string): Sql
 
   type _OnFunctionColumnValue = (table: TableName<any>, column: ColumnName, value: Value) => On
   type _OnFunctionColumnComparison = (


### PR DESCRIPTION
I have modified typescript defs to be able to make these kinds of query 

```typescript
database.collections
       .get<Actor>('actors')
       .query(
        Q.experimentalNestedJoin('remark_actors', 'remarks'),
        Q.on('remark_actors', Q.on('remarks', 'report_id', report.id))
```

```typescript
database.collections
    .get<Remark>('remarks')
    .query(
     Q.experimentalJoinTables(['remark_actors', 'remark_works']), 
     Q.where('report_id', Q.eq(report.id)), 
     Q.unsafeSqlExpr('remark_actors.id is null'), 
     Q.unsafeSqlExpr('remark_works.id is null'))
```

3 modifications needed:
- Add function experimentalNestedJoin
- Modify OnFunction to allow nested Q.on
- Add unsafeSqlExpr clause
