### PR TITLE
fix(unsafefetchrecordswithsql): fix an issue with unsafeFetchRecordsW…

### DIFF
--- a/src/__tests__/testModels.js
+++ b/src/__tests__/testModels.js
@@ -3,6 +3,7 @@ import { field, relation, immutableRelation, text, readonly, date } from '../dec
 import Model from '../Model'
 import Database from '../Database'
 import LokiJSAdapter from '../adapters/lokijs'
+import SQLiteAdapter from '../adapters/sqlite'
 
 export const testSchema = appSchema({
   version: 1,
@@ -100,6 +101,40 @@ export const mockDatabase = ({
     migrations,
     useWebWorker: false,
     useIncrementalIndexedDB: false,
+  })
+  const database = new Database({
+    adapter,
+    schema,
+    modelClasses,
+    actionsEnabled,
+  })
+  return {
+    database,
+    db: database,
+    adapter,
+    projects: database.get('mock_projects'),
+    tasks: database.get('mock_tasks'),
+    comments: database.get('mock_comments'),
+    cloneDatabase: async (clonedSchema = schema) =>
+      // simulate reload
+      new Database({
+        adapter: await database.adapter.underlyingAdapter.testClone({ schema: clonedSchema }),
+        schema: clonedSchema,
+        modelClasses,
+        actionsEnabled,
+      }),
+  }
+}
+
+export const mockDatabaseSQLite = ({
+  actionsEnabled = false,
+  schema = testSchema,
+  migrations = undefined,
+} = {}) => {
+  const adapter = new SQLiteAdapter({
+    dbName: 'test',
+    schema,
+    migrations,
   })
   const database = new Database({
     adapter,


### PR DESCRIPTION
…ithSQL causing a race-condition

This commit fixes an issue where `unsafeFetchRecordsWithSQL` when used in conjunction with a
standard `fetch` in an asynchronous manner while fetching sets of intersecting records  was
resulting in an error due to a race-condition.

https://github.com/Nozbe/WatermelonDB/issues/931