### PR TITLE
Fix Typescript LokiAdapterOptions fields

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -24,5 +24,6 @@
 ### Fixes
 
 - Fixed a race condition when using standard fetch methods alongside `Collection.unsafeFetchRecordsWithSQL` - @jspizziri
+- [Typescript] Added `onSetUpError` and `onIndexedDBFetchStart` fields to `LokiAdapterOptions`; fixes TS error - @3DDario
 
 ### Internal

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -19,6 +19,7 @@
 
 - [Docs] Add advanced tutorial to share database across iOS targets - @thiagobrez
 - [Sqlite] Allowed callbacks (within the migrationEvents object) to be passed so as to track the migration events status ( onStart, onSuccess, onError ) - @avinashlng1080
+- [Typescript] Removed duplicated identifiers `useWebWorker` and `useIncrementalIndexedDB` in `LokiAdapterOptions` - @3DDario
 
 ### Fixes
 

--- a/src/adapters/lokijs/index.d.ts
+++ b/src/adapters/lokijs/index.d.ts
@@ -24,8 +24,6 @@ declare module '@nozbe/watermelondb/adapters/lokijs' {
     useWebWorker?: boolean
     useIncrementalIndexedDB?: boolean
     _testLokiAdapter?: LokiMemoryAdapter
-    useWebWorker?: boolean
-    useIncrementalIndexedDB?: boolean
     onIndexedDBVersionChange?: () => void
     onQuotaExceededError?: (error: any) => void
   }

--- a/src/adapters/lokijs/index.d.ts
+++ b/src/adapters/lokijs/index.d.ts
@@ -26,6 +26,8 @@ declare module '@nozbe/watermelondb/adapters/lokijs' {
     _testLokiAdapter?: LokiMemoryAdapter
     onIndexedDBVersionChange?: () => void
     onQuotaExceededError?: (error: any) => void
+    onSetUpError?: (error: Error) => void
+    onIndexedDBFetchStart?: () => void
   }
 
   export default class LokiJSAdapter implements DatabaseAdapter {


### PR DESCRIPTION
Add `onSetUpError` and `onIndexedDBFetchStart`; remove duplicated fields `useWebWorker` and `useIncrementalIndexedDB`.

`onSetUpError` is also [referenced in the tutorial](https://nozbe.github.io/WatermelonDB/Installation.html#set-up-database).