### PR TITLE
android: refine auto linking and doc

### DIFF
--- a/docs-master/Installation.md
+++ b/docs-master/Installation.md
@@ -119,11 +119,11 @@ On RN60+, auto linking should work.
 
 <details>
   <summary>Custom Kotlin Version</summary>
-  Just set ext properties `kotlinVersion` in `android/build.gradle`
+  Just set ext properties `kotlinVersion` in `android/build.gradle`, and WatermelonDB will use the specified kotlin version.
   
   ```gradle
   buildscript {
-      ext.kotlin_version = '1.3.21'
+      ext.kotlinVersion = '1.3.21'
   }
   ```
 </details>

--- a/docs-master/Installation.md
+++ b/docs-master/Installation.md
@@ -75,45 +75,26 @@ npm install @nozbe/watermelondb
 
 ### Android (React Native)
 
-1. **Set up Babel config in your project**
+**Set up Babel config in your project**
 
-   See instructions above ⬆️
+See instructions above ⬆️  
 
-2. In `android/app/build.gradle`, add:
-   ```gradle
-   apply plugin: "com.android.application"
-   apply plugin: 'kotlin-android'  // ⬅️ This!
-   // ...
-   ```
-3. In `android/build.gradle`, add Kotlin support to the project:
-   ```gradle
-   buildscript {
-       ext.kotlin_version = '1.3.21'
-       // ...
-       dependencies {
-           // ...
-           classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-       }
-   }
-   ```
-4. **Troubleshooting**. If you get this error:
-    > `Can't find variable: Symbol`
+On RN60+, auto linking should work.  
 
-    You're using an ancient version of JSC. Install [`jsc-android`](https://github.com/react-community/jsc-android-buildscripts) or Hermes.
+<details>
+  <summary>Linking Manually</summary>
 
-##### Manual Install ONLY
+  Users on React Native 0.60+ automatically have access to "autolinking", requiring no further manual installation steps. If you are on React Native 0.60+   please skip this section. If you are on React Native < 0.60 please do the following in **addition** to the previous steps:
 
-Users on React Native 0.60+ automatically have access to "autolinking", requiring no further manual installation steps. If you are on React Native 0.60+ please skip to the next section. If you are on React Native < 0.60 please do the following in **addition** to the previous steps:
+  1. In `android/settings.gradle`, add:
 
-1. In `android/settings.gradle`, add:
+  ```gradle
+  include ':watermelondb'
+  project(':watermelondb').projectDir =
+      new File(rootProject.projectDir, '../node_modules/@nozbe/watermelondb/native/android')
+  ```
 
-   ```gradle
-   include ':watermelondb'
-   project(':watermelondb').projectDir =
-       new File(rootProject.projectDir, '../node_modules/@nozbe/watermelondb/native/android')
-   ```
-
-2. In `android/app/build.gradle`, add:
+  2. In `android/app/build.gradle`, add:
   ```gradle
   // ...
   dependencies {
@@ -121,19 +102,40 @@ Users on React Native 0.60+ automatically have access to "autolinking", requirin
       implementation project(':watermelondb')  // ⬅️ This!
   }
   ```
-3. And finally, in `android/app/src/main/java/{YOUR_APP_PACKAGE}/MainApplication.java`, add:
-   ```java
-   // ...
-   import com.nozbe.watermelondb.WatermelonDBPackage; // ⬅️ This!
-   // ...
-   @Override
-   protected List<ReactPackage> getPackages() {
-     return Arrays.<ReactPackage>asList(
-       new MainReactPackage(),
-       new WatermelonDBPackage() // ⬅️ Here!
-     );
-   }
-   ```
+  3. And finally, in `android/app/src/main/java/{YOUR_APP_PACKAGE}/MainApplication.java`, add:
+  ```java
+  // ...
+  import com.nozbe.watermelondb.WatermelonDBPackage; // ⬅️ This!
+  // ...
+  @Override
+  protected List<ReactPackage> getPackages() {
+    return Arrays.<ReactPackage>asList(
+      new MainReactPackage(),
+      new WatermelonDBPackage() // ⬅️ Here!
+    );
+  }
+  ```
+</details>
+
+<details>
+  <summary>Custom Kotlin Version</summary>
+  Just set ext properties `kotlinVersion` in `android/build.gradle`
+  
+  ```gradle
+  buildscript {
+      ext.kotlin_version = '1.3.21'
+  }
+  ```
+</details>
+
+<details>
+  <summary>Troubleshooting</summary>
+  If you get this error:
+    
+  > `Can't find variable: Symbol`  
+    
+  You're using an ancient version of JSC. Install [`jsc-android`](https://github.com/react-community/jsc-android-buildscripts) or Hermes.
+</details>
 
 ## NodeJS setup
 

--- a/docs-master/Installation.md
+++ b/docs-master/Installation.md
@@ -79,24 +79,13 @@ npm install @nozbe/watermelondb
 
    See instructions above ⬆️
 
-2. In `android/settings.gradle`, add:
-
-   ```gradle
-   include ':watermelondb'
-   project(':watermelondb').projectDir =
-       new File(rootProject.projectDir, '../node_modules/@nozbe/watermelondb/native/android')
-   ```
-3. In `android/app/build.gradle`, add:
+2. In `android/app/build.gradle`, add:
    ```gradle
    apply plugin: "com.android.application"
    apply plugin: 'kotlin-android'  // ⬅️ This!
    // ...
-   dependencies {
-       // ...
-       implementation project(':watermelondb')  // ⬅️ This!
-   }
    ```
-4. In `android/build.gradle`, add Kotlin support to the project:
+3. In `android/build.gradle`, add Kotlin support to the project:
    ```gradle
    buildscript {
        ext.kotlin_version = '1.3.21'
@@ -107,7 +96,32 @@ npm install @nozbe/watermelondb
        }
    }
    ```
-5. And finally, in `android/app/src/main/java/{YOUR_APP_PACKAGE}/MainApplication.java`, add:
+4. **Troubleshooting**. If you get this error:
+    > `Can't find variable: Symbol`
+
+    You're using an ancient version of JSC. Install [`jsc-android`](https://github.com/react-community/jsc-android-buildscripts) or Hermes.
+
+##### Manual Install ONLY
+
+Users on React Native 0.60+ automatically have access to "autolinking", requiring no further manual installation steps. If you are on React Native 0.60+ please skip to the next section. If you are on React Native < 0.60 please do the following in **addition** to the previous steps:
+
+1. In `android/settings.gradle`, add:
+
+   ```gradle
+   include ':watermelondb'
+   project(':watermelondb').projectDir =
+       new File(rootProject.projectDir, '../node_modules/@nozbe/watermelondb/native/android')
+   ```
+
+2. In `android/app/build.gradle`, add:
+  ```gradle
+  // ...
+  dependencies {
+      // ...
+      implementation project(':watermelondb')  // ⬅️ This!
+  }
+  ```
+3. And finally, in `android/app/src/main/java/{YOUR_APP_PACKAGE}/MainApplication.java`, add:
    ```java
    // ...
    import com.nozbe.watermelondb.WatermelonDBPackage; // ⬅️ This!
@@ -120,11 +134,6 @@ npm install @nozbe/watermelondb
      );
    }
    ```
-6. **Troubleshooting**. If you get this error:
-    > `Can't find variable: Symbol`
-
-    You're using an ancient version of JSC. Install [`jsc-android`](https://github.com/react-community/jsc-android-buildscripts) or Hermes.
-
 
 ## NodeJS setup
 

--- a/native/android/build.gradle
+++ b/native/android/build.gradle
@@ -1,18 +1,32 @@
+
+buildscript {
+    ext.getExtOrDefault = {name ->
+        return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['ReactNativeWatermelonDB_' + name]
+    }
+
+    ext.getExtOrIntegerDefault = {name ->
+        return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['ReactNativeWatermelonDB_' + name]).toInteger()
+    }
+
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${getExtOrDefault('kotlinVersion')}")
+    }
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
-def DEFAULT_MIN_SDK_VERSION = 16
-def DEFAULT_TARGET_SDK_VERSION = 28
-
 android {
-    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+    compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
+    buildToolsVersion getExtOrDefault('buildToolsVersion')
 
     defaultConfig {
-        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_MIN_SDK_VERSION
-        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+        minSdkVersion getExtOrIntegerDefault('minSdkVersion')
+        targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
         versionCode 1
         versionName "1.0"
     }
@@ -21,8 +35,9 @@ android {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getExtOrDefault('kotlinVersion')}"
 }
+
 repositories {
     mavenCentral()
 }

--- a/native/android/gradle.properties
+++ b/native/android/gradle.properties
@@ -1,0 +1,5 @@
+ReactNativeWatermelonDB_kotlinVersion=1.3.21
+ReactNativeWatermelonDB_compileSdkVersion=28
+ReactNativeWatermelonDB_buildToolsVersion=28.0.3
+ReactNativeWatermelonDB_targetSdkVersion=28
+ReactNativeWatermelonDB_minSdkVersion=16


### PR DESCRIPTION
This is a rework of #959 and #881.

## Motivation

Although on 0.21, the auto linking works, but user still have to manually edit their build.gradle, and the installation doc is a bit outdated.

This PR support real auto linking, means that user does not have to edit their native `build.gradle` files anymore.

Refers to [how react-native-webview handles kotlin version](https://github.com/react-native-webview/react-native-webview/blob/master/android/build.gradle)

## Explain:

In `build.gradle`, the `buildscript` block evaluated first even before the global var definition, and can specify dependency classpath there before building ( the `kotlin gradle plugin` ), so user don't have to specify it in rootProject.

This also is the reason why introducing `gradle.properties` file, since we can't access global vars in `buildscript` block yet.

If user has use `kotlinVersion` ext prop in root project, they can choose to use their own kotlin version avoiding to download different versions unnecessarily.

## Note:

* I changed the kotlin version name from `kotlin_version` to more conventional `kotlinVersion`, given that we are using `kotlin_version` before, and now we support true auto linking without user to specify, I don't think it is a breaking changes.


* I don't change the default android sdk version (currently 28) and kotlin version ( currently 1.3.21), maybe we can change the default to sdk 29 and kotlin 1.3.72, I leave it for maintainer's choice. Let me know if you want me to bump it as well.

