### PR TITLE
Sync: makes `pushChanges` optional

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -18,6 +18,7 @@
 
 ### Changes
 
+- Synchronization: `pushChanges` is optional, will not calculate local changes if not specified.
 - withObservables is now a dependency of WatermelonDB for simpler installation and consistent updates. You can (and generally should) delete `@nozbe/with-observables` from your app's package.json
 - [Docs] Add advanced tutorial to share database across iOS targets - @thiagobrez
 - [Sqlite] Allowed callbacks (within the migrationEvents object) to be passed so as to track the migration events status ( onStart, onSuccess, onError ) - @avinashlng1080

--- a/docs-master/Advanced/Sync.md
+++ b/docs-master/Advanced/Sync.md
@@ -9,7 +9,7 @@ Note that Watermelon is only a local database — you need to **bring your own b
 
 ## Using `synchronize()` in your app
 
-To synchronize, you need to pass two functions, `pullChanges` and `pushChanges` that talk to your backend and are compatible with Watermelon Sync Protocol. The frontend code will look something like this:
+To synchronize, you need to pass `pullChanges` and `pushChanges` _(optional)_ that talk to your backend and are compatible with Watermelon Sync Protocol. The frontend code will look something like this:
 
 ```js
 import { synchronize } from '@nozbe/watermelondb/sync'

--- a/src/sync/impl/synchronize.js
+++ b/src/sync/impl/synchronize.js
@@ -84,6 +84,10 @@ export default async function synchronize({
   }, 'sync-synchronize-apply')
 
   // push phase
+  if (!pushChanges) {
+    log && (log.phase = 'pushChanges not defined')
+    return;
+  }
   log && (log.phase = 'ready to fetch local changes')
 
   const localChanges = await fetchLocalChanges(database)

--- a/src/sync/impl/synchronize.js
+++ b/src/sync/impl/synchronize.js
@@ -11,10 +11,13 @@ import {
   setLastPulledSchemaVersion,
   getMigrationInfo,
 } from './index'
-import { ensureActionsEnabled, ensureSameDatabase, isChangeSetEmpty, changeSetCount } from './helpers'
 import {
-  type SyncArgs,
-} from '../index'
+  ensureActionsEnabled,
+  ensureSameDatabase,
+  isChangeSetEmpty,
+  changeSetCount,
+} from './helpers'
+import { type SyncArgs } from '../index'
 
 export default async function synchronize({
   database,
@@ -84,25 +87,25 @@ export default async function synchronize({
   }, 'sync-synchronize-apply')
 
   // push phase
-  if (!pushChanges) {
-    log && (log.phase = 'pushChanges not defined')
-    return;
-  }
-  log && (log.phase = 'ready to fetch local changes')
+  if (pushChanges) {
+    log && (log.phase = 'ready to fetch local changes')
 
-  const localChanges = await fetchLocalChanges(database)
-  log && (log.localChangeCount = changeSetCount(localChanges.changes))
-  log && (log.phase = 'fetched local changes')
-
-  ensureSameDatabase(database, resetCount)
-  if (!isChangeSetEmpty(localChanges.changes)) {
-    log && (log.phase = 'ready to push')
-    await pushChanges({ changes: localChanges.changes, lastPulledAt: newLastPulledAt })
-    log && (log.phase = 'pushed')
+    const localChanges = await fetchLocalChanges(database)
+    log && (log.localChangeCount = changeSetCount(localChanges.changes))
+    log && (log.phase = 'fetched local changes')
 
     ensureSameDatabase(database, resetCount)
-    await markLocalChangesAsSynced(database, localChanges)
-    log && (log.phase = 'marked local changes as synced')
+    if (!isChangeSetEmpty(localChanges.changes)) {
+      log && (log.phase = 'ready to push')
+      await pushChanges({ changes: localChanges.changes, lastPulledAt: newLastPulledAt })
+      log && (log.phase = 'pushed')
+
+      ensureSameDatabase(database, resetCount)
+      await markLocalChangesAsSynced(database, localChanges)
+      log && (log.phase = 'marked local changes as synced')
+    }
+  } else {
+    log && (log.phase = 'pushChanges not defined')
   }
 
   log && (log.finishedAt = new Date())

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -54,7 +54,7 @@ export type SyncConflictResolver = (
 export type SyncArgs = $Exact<{
   database: Database,
   pullChanges: SyncPullArgs => Promise<SyncPullResult>,
-  pushChanges: SyncPushArgs => Promise<void>,
+  pushChanges?: SyncPushArgs => Promise<void>,
   // version at which support for migration syncs was added - the version BEFORE first syncable migration
   migrationsEnabledAtVersion?: SchemaVersion,
   sendCreatedAsUpdated?: boolean,

--- a/src/sync/test.js
+++ b/src/sync/test.js
@@ -717,6 +717,17 @@ describe('synchronize', () => {
     expect(log.remoteChangeCount).toBe(0)
     expect(log.localChangeCount).toBe(0)
   })
+  it("won't push changes if no `pushChanges`", async () => {
+    const { database } = makeDatabase()
+
+    await makeLocalChanges(database)
+    const localChanges = await fetchLocalChanges(database)
+
+    const pullChanges = jest.fn(emptyPull())
+    const log = {}
+    await synchronize({ database, pullChanges, log })
+    // if it tries to push, it should throw exception
+  })
   it('can push changes', async () => {
     const { database } = makeDatabase()
 

--- a/src/sync/test.js
+++ b/src/sync/test.js
@@ -717,16 +717,18 @@ describe('synchronize', () => {
     expect(log.remoteChangeCount).toBe(0)
     expect(log.localChangeCount).toBe(0)
   })
-  it("won't push changes if no `pushChanges`", async () => {
+  it('will not push changes if no `pushChanges`', async () => {
     const { database } = makeDatabase()
 
     await makeLocalChanges(database)
-    const localChanges = await fetchLocalChanges(database)
 
     const pullChanges = jest.fn(emptyPull())
     const log = {}
     await synchronize({ database, pullChanges, log })
-    // if it tries to push, it should throw exception
+    expect(log.startedAt).toBeInstanceOf(Date)
+    expect(log.finishedAt).toBeInstanceOf(Date)
+    expect(log.finishedAt.getTime()).toBeGreaterThan(log.startedAt.getTime())
+    expect(log.phase).toBe('done')
   })
   it('can push changes', async () => {
     const { database } = makeDatabase()


### PR DESCRIPTION
The idea is to skip all the `localChanges` processing for databases that are "pull-only"