### PR TITLE
update typings for withDatabase()

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -15,6 +15,7 @@
 
 - Removed dependency on rambdax and made the util library smaller
 - Faster withObservables
+- Non-react statics hoisting in `withDatabase()`
 
 ### Changes
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/runtime": "^7.11.2",
     "@nozbe/sqlite": "3.31.1",
     "@nozbe/with-observables": "1.2.1-0",
+    "hoist-non-react-statics": "^3.3.2",
     "lokijs": "npm:@nozbe/lokijs@1.5.12-wmelon2",
     "rxjs": "^6.5.3",
     "sql-escape-string": "^1.1.0"
@@ -90,6 +91,7 @@
     "@babel/plugin-transform-template-literals": "^7.4.4",
     "@babel/plugin-transform-unicode-regex": "^7.4.4",
     "@testing-library/react-hooks": "^3.1.0",
+    "@types/hoist-non-react-statics": "^3.3.1",
     "@types/react": "^16.8.6",
     "anymatch": "^3.0.0",
     "babel-core": "^7.0.0-0",

--- a/src/DatabaseProvider/index.d.ts
+++ b/src/DatabaseProvider/index.d.ts
@@ -1,10 +1,9 @@
 declare module '@nozbe/watermelondb/DatabaseProvider' {
   import * as React from 'react'
   import Database from '@nozbe/watermelondb/Database'
+  import { NonReactStatics } from 'hoist-non-react-statics'
 
   type GetProps<C> = C extends React.ComponentType<infer P & { database?: Database }> ? P : never
-
-  type Statics<C extends React.ComponentType<any>> = { [K in keyof C]: C[K] }
 
   export const DatabaseContext: React.Context<Database>
 
@@ -19,7 +18,7 @@ declare module '@nozbe/watermelondb/DatabaseProvider' {
     C extends React.ComponentType<P>,
     P = GetProps<C>,
     R = Omit<P, 'database'>
-  >(Component: C): React.FunctionComponent<R> & Statics<C>
+  >(Component: C): React.FunctionComponent<R> & NonReactStatics<C>
 
   export default DatabaseProviderComponent
 }

--- a/src/DatabaseProvider/index.d.ts
+++ b/src/DatabaseProvider/index.d.ts
@@ -2,6 +2,10 @@ declare module '@nozbe/watermelondb/DatabaseProvider' {
   import * as React from 'react'
   import Database from '@nozbe/watermelondb/Database'
 
+  type GetProps<C> = C extends React.ComponentType<infer P & { database?: Database }> ? P : never
+
+  type Statics<C extends React.ComponentType<any>> = { [K in keyof C]: C[K] }
+
   export const DatabaseContext: React.Context<Database>
 
   export interface DatabaseProviderProps {
@@ -11,14 +15,11 @@ declare module '@nozbe/watermelondb/DatabaseProvider' {
 
   export const DatabaseProviderComponent: React.ComponentClass<DatabaseProviderProps>
 
-  /**
-   * HOC
-   * https://gist.github.com/thehappybug/88342c122cfb1df9f14c9a10fb4926e4
-   */
-  type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
-  export function withDatabase<P extends { database?: Database }, R = Omit<P, 'database'>>(
-    Component: React.ComponentType<P> | React.FunctionComponent<P>,
-  ): React.FunctionComponent<R>
+  export function withDatabase<
+    C extends React.ComponentType<P>,
+    P = GetProps<C>,
+    R = Omit<P, 'database'>
+  >(Component: C): React.FunctionComponent<R> & Statics<C>
 
   export default DatabaseProviderComponent
 }

--- a/src/DatabaseProvider/withDatabase.js
+++ b/src/DatabaseProvider/withDatabase.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react'
+import hoistNonReactStatics from 'hoist-non-react-statics'
 import type Database from '../Database'
 import { DatabaseConsumer } from './DatabaseContext'
-import hoistNonReactStatics from 'hoist-non-react-statics'
 
 type WithDatabaseProps<T: {}> = {
   ...T,

--- a/src/DatabaseProvider/withDatabase.js
+++ b/src/DatabaseProvider/withDatabase.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import type Database from '../Database'
 import { DatabaseConsumer } from './DatabaseContext'
+import hoistNonReactStatics from 'hoist-non-react-statics'
 
 type WithDatabaseProps<T: {}> = {
   ...T,
@@ -11,7 +12,13 @@ type WithDatabaseProps<T: {}> = {
 export default function withDatabase<T: {}>(
   Component: React$ComponentType<WithDatabaseProps<T>>,
 ): React$ComponentType<T> {
-  return function DatabaseComponent(props): React$Element<*> {
-    return <DatabaseConsumer>{(database: Database) => <Component {...props} database={database} />}</DatabaseConsumer>
+  function DatabaseComponent(props): React$Element<*> {
+    return (
+      <DatabaseConsumer>
+        {(database: Database) => <Component {...props} database={database} />}
+      </DatabaseConsumer>
+    )
   }
+
+  return hoistNonReactStatics(DatabaseComponent, Component)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1778,6 +1778,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -4795,7 +4803,7 @@ hoist-non-react-statics@^2.5.0:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==


### PR DESCRIPTION
#### add static hoisting

```ts
class Foo extends Component {
  static foo() {}
}

const Baz = withDatabase(Foo)

Baz.foo()  // TS Error: Property 'foo' does not exist
```

#### optional requirement on `database` prop

```ts
type Props = {
  foo: number
}

class Foo extends Component<Props> {}

export default withDatabase(Foo)  // TS Error: Property 'foo' is missing in type '{ database?: Database | undefined; }' but required in type 'Readonly<{ foo: number; }>'.
```

#### allow `Database` subclass as prop

```ts
class MyDatabase extends Database {
  foo() {} // extra class member required to trigger TS error
}

type Props = {
  database: MyDatabase
}

class Foo extends Component<Props> {}

export default withDatabase(Foo)  // TS Error: Property 'foo' is missing in type '{ database?: Database | undefined; }' but required in type 'Readonly<{ foo: number; }>'.  // TS Error: Property 'foo' is missing in type 'Database' but required in type 'MyDatabase'

```
