### PR TITLE
update logger typings

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -37,5 +37,6 @@
 - withObservables shouldn't cause any RxJS issues anymore as it no longer imports RxJS
 - [Typescript] Added `onSetUpError` and `onIndexedDBFetchStart` fields to `LokiAdapterOptions`; fixes TS error - @3DDario
 - [Typescript] Removed duplicated identifiers `useWebWorker` and `useIncrementalIndexedDB` in `LokiAdapterOptions` - @3DDario
+- [Typescript] Fix default export in logger util
 
 ### Internal

--- a/src/utils/common/logger/index.d.ts
+++ b/src/utils/common/logger/index.d.ts
@@ -1,5 +1,5 @@
 declare module '@nozbe/watermelondb/utils/common/logger' {
-  export default class Logger {
+  class Logger {
     log(...messages: any[]): void
 
     warn(...messages: any[]): void
@@ -8,4 +8,8 @@ declare module '@nozbe/watermelondb/utils/common/logger' {
 
     silence(): void
   }
+
+  const logger: Logger
+  
+  export default logger
 }


### PR DESCRIPTION
logger util exports an instance of `Logger` class and not the class itself

https://github.com/Nozbe/WatermelonDB/blob/3ebce9bd9026cdf608a03c7a4ad1ddc7f855331a/src/utils/common/logger/index.js#L22-L24