### PR TITLE
Adds `pushChanges` queries for sync customization

### DIFF
--- a/src/Collection/RecordCache.js
+++ b/src/Collection/RecordCache.js
@@ -34,6 +34,9 @@ export default class RecordCache<Record: Model> {
   }
 
   add(record: Record): void {
+    if (record.syncStatus === 'deleted') {
+      return
+    }
     this.map.set(record.id, record)
   }
 
@@ -109,7 +112,9 @@ export default class RecordCache<Record: Model> {
 
     // Return new model
     const newRecord = this.recordInsantiator(raw)
-    this.add(newRecord)
+    if (newRecord.syncStatus !== 'deleted') {
+      this.add(newRecord)
+    }
     return newRecord
   }
 }

--- a/src/Collection/index.js
+++ b/src/Collection/index.js
@@ -83,6 +83,10 @@ export default class Collection<Record: Model> {
     return new Query(this, clauses)
   }
 
+  queryWithDeleted(...clauses: Clause[]): Query<Record> {
+    return new Query(this, clauses, false)
+  }
+
   // Creates a new record in this collection
   // Pass a function to set attributes of the record.
   //

--- a/src/Collection/test.js
+++ b/src/Collection/test.js
@@ -105,6 +105,17 @@ describe('finding records', () => {
 })
 
 describe('fetching queries', () => {
+  it('build queries', () => {
+    const { tasks: collection, adapter } = mockDatabase()
+    adapter.query = jest.fn()
+
+    collection.query().fetch()
+    expect(adapter.query.mock.calls[0][0].description.where.length).toBe(1)
+
+    adapter.query.mockClear()
+    collection.queryWithDeleted().fetch()
+    expect(adapter.query.mock.calls[0][0].description.where.length).toBe(0)
+  })
   it('fetches queries and caches records', async () => {
     const { tasks: collection, adapter } = mockDatabase()
 

--- a/src/Query/index.js
+++ b/src/Query/index.js
@@ -64,10 +64,16 @@ export default class Query<Record: Model> {
   )
 
   // Note: Don't use this directly, use Collection.query(...)
-  constructor(collection: Collection<Record>, clauses: Clause[]): void {
+  constructor(
+    collection: Collection<Record>,
+    clauses: Clause[],
+    skipDeleted: boolean = true,
+  ): void {
     this.collection = collection
     this._rawDescription = Q.buildQueryDescription(clauses)
-    this.description = Q.queryWithoutDeleted(this._rawDescription)
+    this.description = skipDeleted
+      ? Q.queryWithoutDeleted(this._rawDescription)
+      : this._rawDescription
   }
 
   // Creates a new Query that extends the clauses of this query

--- a/src/Query/test.js
+++ b/src/Query/test.js
@@ -38,6 +38,24 @@ describe('Query', () => {
       expect(query.table).toBe('mock_tasks')
       expect(query.secondaryTables).toEqual([])
       expect(query.allTables).toEqual(['mock_tasks'])
+
+      expect(query._rawDescription.where.length).toBe(1)
+      expect(query._rawDescription.where[0].comparison.right.value).toBe('abcdef')
+
+      expect(query.description.where.length).toBe(2)
+      expect(query.description.where[0].comparison.right.value).toBe('abcdef')
+      expect(query.description.where[1].comparison.operator).toBe('notEq')
+      expect(query.description.where[1].comparison.right.value).toBe('deleted')
+
+      expect(query._rawDescription.where[0]).toEqual(query.description.where[0])
+
+      const queryWithDeleted = new Query(mockCollection, [Q.where('id', 'abcdef')], false)
+      expect(queryWithDeleted.table).toBe(query.table)
+      expect(queryWithDeleted.secondaryTables).toEqual(query.secondaryTables)
+      expect(queryWithDeleted.allTables).toEqual(query.allTables)
+      expect(queryWithDeleted._rawDescription).toEqual(query._rawDescription)
+      expect(queryWithDeleted.description).toEqual(query._rawDescription)
+      expect(queryWithDeleted.description).not.toEqual(query.description)
     })
     it('fetches tables correctly for complex queries', () => {
       const query = new Query(mockCollection, [

--- a/src/adapters/lokijs/worker/executor.js
+++ b/src/adapters/lokijs/worker/executor.js
@@ -426,8 +426,10 @@ export default class LokiExecutor {
       if (cache.has(id)) {
         return id
       }
+      if (raw._status !== 'deleted') {
+        cache.add(id)
+      }
 
-      cache.add(id)
       return sanitizedRaw(raw, this.schema.tables[table])
     })
   }

--- a/src/sync/impl/fetchLocal.js
+++ b/src/sync/impl/fetchLocal.js
@@ -11,6 +11,7 @@ import {
 import allPromisesObj from '../../utils/fp/allPromisesObj'
 import type { Database, Collection, Model } from '../..'
 import * as Q from '../../QueryDescription'
+import type { Clause } from '../../QueryDescription'
 import { columnName } from '../../Schema'
 
 import type { SyncTableChangeSet, SyncLocalChanges } from '../index'
@@ -18,38 +19,69 @@ import type { SyncTableChangeSet, SyncLocalChanges } from '../index'
 // NOTE: Two separate queries are faster than notEq(synced) on LokiJS
 const createdQuery = Q.where(columnName('_status'), 'created')
 const updatedQuery = Q.where(columnName('_status'), 'updated')
+const deletedQuery = Q.where(columnName('_status'), 'deleted')
 
-async function fetchLocalChangesForCollection<T: Model>(
+type fetchLocalChangesForCollectionArgs<T> = {
   collection: Collection<T>,
-): Promise<[SyncTableChangeSet, T[]]> {
+  createdQueries?: Clause[],
+  updatedQueries?: Clause[],
+  deletedQueries?: Clause[],
+}
+
+async function fetchLocalChangesForCollection<T: Model>({
+  collection,
+  createdQueries = [],
+  updatedQueries = [],
+  deletedQueries = [],
+}: fetchLocalChangesForCollectionArgs<T>): Promise<[SyncTableChangeSet, T[]]> {
   const [createdRecords, updatedRecords, deletedRecords] = await Promise.all([
-    collection.query(createdQuery).fetch(),
-    collection.query(updatedQuery).fetch(),
-    collection.database.adapter.getDeletedRecords(collection.table),
+    collection.query(createdQuery, ...createdQueries).fetch(),
+    collection.query(updatedQuery, ...updatedQueries).fetch(),
+    collection.queryWithDeleted(deletedQuery, ...deletedQueries).fetch(),
   ])
+
   const changeSet = {
-    created: [],
-    updated: [],
-    deleted: deletedRecords,
+    // TODO: It would be best to omit _status, _changed fields, since they're not necessary for the server
+    // but this complicates markLocalChangesAsDone, since we don't have the exact copy to compare if record changed
+    created: createdRecords.map((record) => Object.assign({}, record._raw)),
+    // TODO: It would probably also be good to only send to server locally changed fields, not full records
+    // perf-critical - using mutation
+    updated: updatedRecords.map((record) => Object.assign({}, record._raw)),
+    deleted: deletedRecords.map((record) => record.id),
+    // deleted: deletedRecords,
   }
-  // TODO: It would be best to omit _status, _changed fields, since they're not necessary for the server
-  // but this complicates markLocalChangesAsDone, since we don't have the exact copy to compare if record changed
-  // TODO: It would probably also be good to only send to server locally changed fields, not full records
-  // perf-critical - using mutation
-  createdRecords.forEach((record) => {
-    changeSet.created.push(Object.assign({}, record._raw))
-  })
-  updatedRecords.forEach((record) => {
-    changeSet.updated.push(Object.assign({}, record._raw))
-  })
+
   const changedRecords = createdRecords.concat(updatedRecords)
 
   return [changeSet, changedRecords]
 }
 
-export default function fetchLocalChanges(db: Database): Promise<SyncLocalChanges> {
+type fetchLocalChangesArgs = {
+  database: Database,
+  createdQueries?: Clause[],
+  updatedQueries?: Clause[],
+  deletedQueries?: Clause[],
+}
+
+export default function fetchLocalChanges({
+  database: db,
+  createdQueries,
+  updatedQueries,
+  deletedQueries,
+}: fetchLocalChangesArgs): Promise<SyncLocalChanges> {
   return db.action(async () => {
-    const changes = await allPromisesObj(mapObj(fetchLocalChangesForCollection, db.collections.map))
+    const changes = await allPromisesObj(
+      mapObj(
+        (collection) =>
+          fetchLocalChangesForCollection({
+            collection,
+            createdQueries,
+            updatedQueries,
+            deletedQueries,
+          }),
+        db.collections.map,
+      ),
+    )
     // TODO: deep-freeze changes object (in dev mode only) to detect mutations (user bug)
     return {
       // $FlowFixMe

--- a/src/sync/impl/synchronize.js
+++ b/src/sync/impl/synchronize.js
@@ -17,6 +17,9 @@ import { type SyncArgs } from '../index'
 export default async function synchronize({
   database,
   pullChanges,
+  pushChangesCreatedQueries,
+  pushChangesUpdatedQueries,
+  pushChangesDeletedQueries,
   pushChanges,
   sendCreatedAsUpdated = false,
   migrationsEnabledAtVersion,
@@ -84,7 +87,12 @@ export default async function synchronize({
   if (pushChanges) {
     log && (log.phase = 'ready to fetch local changes')
 
-    const localChanges = await fetchLocalChanges(database)
+    const localChanges = await fetchLocalChanges({
+      database,
+      createdQueries: pushChangesCreatedQueries,
+      updatedQueries: pushChangesUpdatedQueries,
+      deletedQueries: pushChangesDeletedQueries,
+    })
     log && (log.localChangeCount = changeSetCount(localChanges.changes))
     log && (log.phase = 'fetched local changes')
 

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -2,6 +2,7 @@
 
 import type { Database, RecordId, TableName, Model } from '..'
 import { type DirtyRaw } from '../RawRecord'
+import type { Clause } from '../QueryDescription'
 
 import { hasUnsyncedChanges as hasUnsyncedChangesImpl } from './impl'
 import type { SchemaVersion } from '../Schema'
@@ -52,6 +53,9 @@ export type SyncConflictResolver = (
 export type SyncArgs = $Exact<{
   database: Database,
   pullChanges: (SyncPullArgs) => Promise<SyncPullResult>,
+  pushChangesCreatedQueries?: Clause[],
+  pushChangesUpdatedQueries?: Clause[],
+  pushChangesDeletedQueries?: Clause[],
   pushChanges?: (SyncPushArgs) => Promise<void>,
   // version at which support for migration syncs was added - the version BEFORE first syncable migration
   migrationsEnabledAtVersion?: SchemaVersion,


### PR DESCRIPTION
Based on #1027

The suggestion is to add extra parameters to `pushChanges` so people can customize the sync process.

> Note: It required more changes than I expected and I'm not sure I'm happy with it.