### PR TITLE
Turbo - part 3

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -44,6 +44,7 @@
 - The order of Q. clauses in a query is now preserved - previously, the clauses could get rearranged and produce a suboptimal query
 - [SQLite] `adapter.batch()` with large numbers of created/updated/deleted records is now between 16-48% faster
 - [LokiJS] Querying and finding is now faster - unnecessary data copy is skipped
+- [jsi] 15-30% faster querying on JSC (iOS) when the number of returned records is large
 
 ### Changes
 

--- a/native/shared/Database.h
+++ b/native/shared/Database.h
@@ -19,6 +19,7 @@ class Database : public jsi::HostObject {
 
     jsi::Value find(jsi::String &tableName, jsi::String &id);
     jsi::Value query(jsi::String &tableName, jsi::String &sql, jsi::Array &arguments);
+    jsi::Value queryAsArray(jsi::String &tableName, jsi::String &sql, jsi::Array &arguments);
     jsi::Array queryIds(jsi::String &sql, jsi::Array &arguments);
     jsi::Array unsafeQueryRaw(jsi::String &sql, jsi::Array &arguments);
     jsi::Value count(jsi::String &sql, jsi::Array &arguments);
@@ -46,6 +47,8 @@ class Database : public jsi::HostObject {
     bool getNextRowOrTrue(sqlite3_stmt *stmt);
     void executeMultiple(std::string sql);
     jsi::Object resultDictionary(sqlite3_stmt *statement);
+    jsi::Array resultArray(sqlite3_stmt *statement);
+    jsi::Array resultColumns(sqlite3_stmt *statement);
     jsi::Array arrayFromStd(std::vector<jsi::Value> &vector);
 
     void beginTransaction();

--- a/native/shared/DatabaseInstallation.cpp
+++ b/native/shared/DatabaseInstallation.cpp
@@ -144,6 +144,13 @@ void Database::install(jsi::Runtime *runtime) {
             jsi::Array arguments = args[2].getObject(rt).getArray(rt);
             return database->query(tableName, sql, arguments);
         });
+        createMethod(rt, adapter, "queryAsArray", 3, [database](jsi::Runtime &rt, const jsi::Value *args) {
+            assert(database->initialized_);
+            jsi::String tableName = args[0].getString(rt);
+            jsi::String sql = args[1].getString(rt);
+            jsi::Array arguments = args[2].getObject(rt).getArray(rt);
+            return database->queryAsArray(tableName, sql, arguments);
+        });
         createMethod(rt, adapter, "queryIds", 2, [database](jsi::Runtime &rt, const jsi::Value *args) {
             assert(database->initialized_);
             jsi::String sql = args[0].getString(rt);

--- a/src/adapters/sqlite/makeDispatcher/decodeQueryResult/index.js
+++ b/src/adapters/sqlite/makeDispatcher/decodeQueryResult/index.js
@@ -1,0 +1,32 @@
+// @flow
+
+// Compressed records have this syntax:
+// [
+//   ['id', 'body', ...], // 0: column names
+//   ['foo', 'bar', ...], // values matching column names
+//   'id',                // only cached id
+// ]
+export default function decodeQueryResult(compressedRecords: any[]): any[] {
+  const len = compressedRecords.length
+  if (!len) {
+    return []
+  }
+  const columnNames = compressedRecords[0]
+  const columnsLen = columnNames.length
+
+  const rawRecords = new Array(len - 1)
+  let rawRecord, compressedRecord
+  for (let i = 1; i < len; i++) {
+    compressedRecord = compressedRecords[i]
+    if (typeof compressedRecord === 'string') {
+      rawRecord = compressedRecord
+    } else {
+      rawRecord = {}
+      for (let j = 0; j < columnsLen; j++) {
+        rawRecord[columnNames[j]] = compressedRecord[j]
+      }
+    }
+    rawRecords[i - 1] = rawRecord
+  }
+  return rawRecords
+}

--- a/src/adapters/sqlite/makeDispatcher/decodeQueryResult/test.js
+++ b/src/adapters/sqlite/makeDispatcher/decodeQueryResult/test.js
@@ -1,0 +1,21 @@
+import decodeQueryResult from './index'
+
+describe('decodeQueryResult', () => {
+  it(`decodes query result`, () => {
+    expect(decodeQueryResult([])).toEqual([])
+    expect(decodeQueryResult([['a', 'b', 'c']])).toEqual([])
+    expect(
+      decodeQueryResult([
+        ['a', 'b', 'c'],
+        [1, 2, 3],
+      ]),
+    ).toEqual([{ a: 1, b: 2, c: 3 }])
+    expect(decodeQueryResult([['a', 'b', 'c'], 'foo'])).toEqual(['foo'])
+    expect(decodeQueryResult([['a', 'b', 'c'], 'foo', [1, 2, 3], 'bar', [10, 20, 30]])).toEqual([
+      'foo',
+      { a: 1, b: 2, c: 3 },
+      'bar',
+      { a: 10, b: 20, c: 30 },
+    ])
+  })
+})


### PR DESCRIPTION
15-30% faster queries on iOS thanks to a trick where results are serialized over the bridge as value arrays and then decoded into POJOS on JS side. Additional 15% speedup was possible using JSON serialization, but it didn't provide any benefit on Android, and had a more significant cost in complexity/maintenance (extra json serialization library) + potential for OOM-inducing memory usage spikes, so I decided it's not worth pursuing that optimization.