### PR TITLE
fix(typescript): incorrect action, writer and reader types

### DIFF
--- a/src/decorators/action/index.d.ts
+++ b/src/decorators/action/index.d.ts
@@ -1,13 +1,8 @@
 declare module '@nozbe/watermelondb/decorators/action' {
-  // Copied from lib.es5.d.ts, MethodDecorator
-  function action<T>(
-    target: Object,
-    propertyKey: string | symbol,
-    descriptor: TypedPropertyDescriptor<T>,
-  ): TypedPropertyDescriptor<T> | void
-  function action(): MethodDecorator
+  const action: MethodDecorator
 
   export default action
-  export function writer(): MethodDecorator
-  export function reader(): MethodDecorator
+
+  export const writer: MethodDecorator
+  export const reader: MethodDecorator
 }


### PR DESCRIPTION
Using last version (`0.23.0.4`), I have a misleading typescript issue 

```'reader' accepts too few arguments to be used as a decorator here. Did you mean to call it first and write '@reader()'?ts(1329)```

on my method 

```
 @reader async getParents() {
    ....
    return directoryList;
  }
```

There is a typescript issue (which was hidden on `action` case with 2 definitions) 
