### PR TITLE
fix(typescript): missing unsafeSqlQuery method

### DIFF
--- a/src/QueryDescription/index.d.ts
+++ b/src/QueryDescription/index.d.ts
@@ -78,8 +78,14 @@ declare module '@nozbe/watermelondb/QueryDescription' {
     type: 'sql'
     expr: string
   }
+  export interface SqlQuery{
+    type: 'sqlQuery',
+    sql: string,
+    values: Value[]
+  }
 
-  export type Clause = Where | On | SortBy | Take | Skip | Join | NestedJoin | Sql
+
+  export type Clause = Where | On | SortBy | Take | Skip | Join | NestedJoin | Sql | SqlQuery
   export interface QueryDescription {
     where: Where[]
     join: On[]
@@ -114,6 +120,7 @@ declare module '@nozbe/watermelondb/QueryDescription' {
   export function experimentalNestedJoin(from: TableName<any>, to: TableName<any>): NestedJoin
   export function sanitizeLikeString(value: string): string
   export function unsafeSqlExpr(sql: string): Sql
+  export function unsafeSqlQuery(sql: string): SqlQuery
 
   type _OnFunctionColumnValue = (table: TableName<any>, column: ColumnName, value: Value) => On
   type _OnFunctionColumnComparison = (


### PR DESCRIPTION
New method `sqlUnsafeQuery` is missing in typescript definitions