### PR TITLE
Turbo - part 7

### DIFF
--- a/native/android-jsi/src/main/cpp/DatabasePlatformAndroid.h
+++ b/native/android-jsi/src/main/cpp/DatabasePlatformAndroid.h
@@ -6,6 +6,7 @@ namespace watermelondb {
 namespace platform {
 
 void configureJNI(JNIEnv *env);
+void provideJson(int id, jbyteArray array);
 
 } // namespace platform
 } // namespace watermelondb

--- a/native/android-jsi/src/main/cpp/JSIInstaller.cpp
+++ b/native/android-jsi/src/main/cpp/JSIInstaller.cpp
@@ -13,3 +13,7 @@ extern "C" JNIEXPORT void JNICALL Java_com_nozbe_watermelondb_jsi_JSIInstaller_i
     watermelondb::platform::configureJNI(env);
     watermelondb::Database::install(runtime);
 }
+
+extern "C" JNIEXPORT void JNICALL Java_com_nozbe_watermelondb_jsi_JSIInstaller_provideSyncJson(JNIEnv *env, jclass clazz, jint id, jbyteArray array) {
+    watermelondb::platform::provideJson(id, array);
+}

--- a/native/android-jsi/src/main/java/com/nozbe/watermelondb/jsi/JSIInstaller.java
+++ b/native/android-jsi/src/main/java/com/nozbe/watermelondb/jsi/JSIInstaller.java
@@ -20,6 +20,8 @@ class JSIInstaller {
 
     private native void installBinding(long javaScriptContextHolder);
 
+    static native void provideSyncJson(int id, byte[] json);
+
     private static Context context;
 
     static {

--- a/native/android-jsi/src/main/java/com/nozbe/watermelondb/jsi/WatermelonJSI.java
+++ b/native/android-jsi/src/main/java/com/nozbe/watermelondb/jsi/WatermelonJSI.java
@@ -7,4 +7,8 @@ public class WatermelonJSI {
     public static void onTrimMemory(int level) {
       // TODO: Unimplemented
     }
+
+    public static void provideSyncJson(int id, byte[] json) {
+        JSIInstaller.provideSyncJson(id, json);
+    }
 }

--- a/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
@@ -208,7 +208,7 @@ class DatabaseBridge(private val reactContext: ReactApplicationContext) :
         // Note: WatermelonJSI is optional on Android, but we don't want users to have to set up
         // yet another NativeModule, so we're using Reflection to access it from here
         val clazz = Class.forName("com.nozbe.watermelondb.jsi.WatermelonJSI")
-        val method = clazz.getDeclaredMethod("provideSyncJson", Int.javaClass, ByteArray::class.java)
+        val method = clazz.getDeclaredMethod("provideSyncJson", Int::class.java, ByteArray::class.java)
         method.invoke(null, id, json.toByteArray())
         promise.resolve(true)
     }

--- a/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
@@ -204,11 +204,12 @@ class DatabaseBridge(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun provideSyncJson(id: Int, json: String) {
+    fun provideSyncJson(id: Int, json: String, promise: Promise) {
         // Note: WatermelonJSI is optional on Android, but we don't want users to have to set up
         // yet another NativeModule, so we're using Reflection to access it from here
         val clazz = Class.forName("com.nozbe.watermelondb.jsi.WatermelonJSI")
         val method = clazz.getDeclaredMethod("provideSyncJson", Int.javaClass, ByteArray::class.java)
         method.invoke(null, id, json.toByteArray())
+        promise.resolve(true)
     }
 }

--- a/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/DatabaseBridge.kt
@@ -202,4 +202,13 @@ class DatabaseBridge(private val reactContext: ReactApplicationContext) :
             operation()
         }
     }
+
+    @ReactMethod
+    fun provideSyncJson(id: Int, json: String) {
+        // Note: WatermelonJSI is optional on Android, but we don't want users to have to set up
+        // yet another NativeModule, so we're using Reflection to access it from here
+        val clazz = Class.forName("com.nozbe.watermelondb.jsi.WatermelonJSI")
+        val method = clazz.getDeclaredMethod("provideSyncJson", Int.javaClass, ByteArray::class.java)
+        method.invoke(null, id, json.toByteArray())
+    }
 }

--- a/native/ios/WatermelonDB/DatabaseBridge.m
+++ b/native/ios/WatermelonDB/DatabaseBridge.m
@@ -69,4 +69,10 @@ WMELON_BRIDGE_METHOD(getLocal,
 
 RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(initializeJSI)
 
+RCT_EXTERN_METHOD(provideSyncJson:(nonnull NSNumber *)id \
+  json:(nonnull NSString *)json \
+  resolve:(RCTPromiseResolveBlock)resolve \
+  reject:(RCTPromiseRejectBlock)reject \
+)
+
 @end

--- a/native/ios/WatermelonDB/DatabaseBridge.swift
+++ b/native/ios/WatermelonDB/DatabaseBridge.swift
@@ -94,6 +94,19 @@ extension DatabaseBridge {
         }
         return [:]
     }
+    
+    @objc(provideSyncJson:json:resolve:reject:)
+    func provideSyncJson(id: NSNumber,
+                         json: NSString,
+                         resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        var error: NSError?
+        watermelondbProvideSyncJson(id.int32Value, json.data(using: String.Encoding.utf8.rawValue), &error)
+        if let error = error {
+            sendReject(reject, error)
+        } else {
+            resolve(true)
+        }
+    }
 }
 
 // MARK: - Asynchronous actions

--- a/native/ios/WatermelonDB/JSIInstaller.h
+++ b/native/ios/WatermelonDB/JSIInstaller.h
@@ -8,6 +8,7 @@ extern "C"
 #endif
 
 void installWatermelonJSI(RCTCxxBridge *bridge);
+void watermelondbProvideSyncJson(int id, NSData *json, NSError **errorPtr);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/native/shared/Database.cpp
+++ b/native/shared/Database.cpp
@@ -730,12 +730,14 @@ std::string insertSqlFor(jsi::Runtime &rt, std::string tableName, TableSchemaArr
     return sql;
 }
 
-jsi::Value Database::unsafeLoadFromSync(std::string_view jsonStr, jsi::Object &schema) {
+jsi::Value Database::unsafeLoadFromSync(std::string_view jsonStr, jsi::Object &schema, std::string preamble, std::string postamble) {
     using namespace simdjson;
     auto &rt = getRt();
     beginTransaction();
 
     try {
+        executeMultiple(preamble);
+        
         jsi::Object residualValues(rt);
         auto tableSchemas = schema.getProperty(rt, "tables").getObject(rt);
 
@@ -847,7 +849,7 @@ jsi::Value Database::unsafeLoadFromSync(std::string_view jsonStr, jsi::Object &s
                 }
             }
         }
-
+        executeMultiple(postamble);
         commit();
         return residualValues;
     } catch (const std::exception &ex) {

--- a/native/shared/Database.cpp
+++ b/native/shared/Database.cpp
@@ -695,7 +695,7 @@ ColumnType columnTypeFromStr(std::string &type) {
 
 using TableSchemaArray = std::vector<ColumnSchema>;
 using TableSchema = std::unordered_map<std::string, ColumnSchema>;
-std::pair<TableSchemaArray, TableSchema> decodeTableSchema(jsi::Runtime &rt, jsi::Object &schema) {
+std::pair<TableSchemaArray, TableSchema> decodeTableSchema(jsi::Runtime &rt, jsi::Object schema) {
     auto columnArr = schema.getProperty(rt, "columnArray").getObject(rt).getArray(rt);
 
     TableSchemaArray columnsArray = {};
@@ -775,8 +775,11 @@ jsi::Value Database::unsafeLoadFromSync(std::string_view jsonStr, jsi::Object &s
                             throw jsi::JSError(rt, "bad changeset field");
                         }
 
-                        auto tableSchemaJsi = tableSchemas.getProperty(rt, jsi::String::createFromUtf8(rt, tableName)).getObject(rt);
-                        auto tableSchemas = decodeTableSchema(rt, tableSchemaJsi);
+                        auto tableSchemaJsi = tableSchemas.getProperty(rt, jsi::String::createFromUtf8(rt, tableName));
+                        if (!tableSchemaJsi.isObject()) {
+                            continue;
+                        }
+                        auto tableSchemas = decodeTableSchema(rt, tableSchemaJsi.getObject(rt));
                         auto tableSchemaArray = tableSchemas.first;
                         auto tableSchema = tableSchemas.second;
 

--- a/native/shared/Database.h
+++ b/native/shared/Database.h
@@ -26,7 +26,7 @@ class Database : public jsi::HostObject {
     jsi::Value count(jsi::String &sql, jsi::Array &arguments);
     void batch(jsi::Array &operations);
     void batchJSON(jsi::String &&operationsJson);
-    jsi::Value unsafeLoadFromSync(std::string_view json, jsi::Object &schema);
+    jsi::Value unsafeLoadFromSync(std::string_view json, jsi::Object &schema, std::string preamble, std::string postamble);
     void unsafeResetDatabase(jsi::String &schema, int schemaVersion);
     jsi::Value getLocal(jsi::String &key);
 

--- a/native/shared/Database.h
+++ b/native/shared/Database.h
@@ -26,7 +26,7 @@ class Database : public jsi::HostObject {
     jsi::Value count(jsi::String &sql, jsi::Array &arguments);
     void batch(jsi::Array &operations);
     void batchJSON(jsi::String &&operationsJson);
-    jsi::Value unsafeLoadFromSync(std::string_view json, jsi::Object &schema, std::string preamble, std::string postamble);
+    jsi::Value unsafeLoadFromSync(int jsonId, jsi::Object &schema, std::string preamble, std::string postamble);
     void unsafeResetDatabase(jsi::String &schema, int schemaVersion);
     jsi::Value getLocal(jsi::String &key);
 

--- a/native/shared/DatabaseInstallation.cpp
+++ b/native/shared/DatabaseInstallation.cpp
@@ -187,11 +187,11 @@ void Database::install(jsi::Runtime *runtime) {
         });
         createMethod(rt, adapter, "unsafeLoadFromSync", 4, [database](jsi::Runtime &rt, const jsi::Value *args) {
             assert(database->initialized_);
-            auto pullResult = args[0].getString(rt);
+            auto jsonId = (int) args[0].getNumber();
             auto schema = args[1].getObject(rt);
             auto preamble = args[2].getString(rt).utf8(rt);
             auto postamble = args[3].getString(rt).utf8(rt);
-            return database->unsafeLoadFromSync(pullResult.utf8(rt), schema, preamble, postamble);
+            return database->unsafeLoadFromSync(jsonId, schema, preamble, postamble);
         });
         createMethod(rt, adapter, "unsafeResetDatabase", 2, [database](jsi::Runtime &rt, const jsi::Value *args) {
             assert(database->initialized_);

--- a/native/shared/DatabaseInstallation.cpp
+++ b/native/shared/DatabaseInstallation.cpp
@@ -185,11 +185,13 @@ void Database::install(jsi::Runtime *runtime) {
             jsi::String key = args[0].getString(rt);
             return database->getLocal(key);
         });
-        createMethod(rt, adapter, "unsafeLoadFromSync", 2, [database](jsi::Runtime &rt, const jsi::Value *args) {
+        createMethod(rt, adapter, "unsafeLoadFromSync", 4, [database](jsi::Runtime &rt, const jsi::Value *args) {
             assert(database->initialized_);
             auto pullResult = args[0].getString(rt);
             auto schema = args[1].getObject(rt);
-            return database->unsafeLoadFromSync(pullResult.utf8(rt), schema);
+            auto preamble = args[2].getString(rt).utf8(rt);
+            auto postamble = args[3].getString(rt).utf8(rt);
+            return database->unsafeLoadFromSync(pullResult.utf8(rt), schema, preamble, postamble);
         });
         createMethod(rt, adapter, "unsafeResetDatabase", 2, [database](jsi::Runtime &rt, const jsi::Value *args) {
             assert(database->initialized_);

--- a/native/shared/DatabasePlatform.h
+++ b/native/shared/DatabasePlatform.h
@@ -26,5 +26,11 @@ void deleteDatabaseFile(std::string path, bool warnIfDoesNotExist);
 // Calls function when device memory is getting low
 void onMemoryAlert(std::function<void(void)> callback);
 
+// Returns sync json provided by the user
+std::string_view getSyncJson(int id);
+
+// Destroys sync json after it's used
+void deleteSyncJson(int id);
+
 } // namespace platform
 } // namespace watermelondb

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -607,14 +607,21 @@ export default () => {
               { id: 't3', str: 'hy', strN: 'true', num: 3.14, bool: null, boolN: false },
             ],
             created: expectedSanitizations.map(({ value }, i) => ({
-              id: `x${i}`,
-              str: value,
-              strN: value,
+              // NOTE: Intentionally in wrong order
               num: value,
+              str: value,
+              boolN: value,
+              id: `x${i}`,
+              strN: value,
               numN: value,
               bool: value,
-              boolN: value,
             })),
+          },
+          tasks: {
+            created: [{ id: 't1', text1: 'hello' }],
+          },
+          bad_table: {
+            created: [],
           },
         },
       }),
@@ -643,6 +650,9 @@ export default () => {
         bool: sqlBool(values.boolean[0]),
         boolN: sqlBool(values.boolean[1]),
       })),
+    ])
+    expect(await adapter.query(taskQuery())).toEqual([
+      mockTaskRaw({ id: 't1', text1: 'hello', _status: 'synced' }),
     ])
     await expectToRejectWithMessage(
       adapter.unsafeLoadFromSync(JSON.stringify({ changes: { tasks: { deleted: ['t1', 't2'] } } })),

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -584,7 +584,7 @@ export default () => {
     }
 
     const loadFromSync = async (json) => {
-      const id = Math.round(Math.random() * 1_000_000_000)
+      const id = Math.round(Math.random() * 1000 * 1000 * 1000)
       await adapter.provideSyncJson(id, JSON.stringify(json))
       return adapter.unsafeLoadFromSync(id)
     }
@@ -679,7 +679,7 @@ export default () => {
     }
 
     const check = async (obj) => {
-      const id = Math.round(Math.random() * 1_000_000_000)
+      const id = Math.round(Math.random() * 1000 * 1000 * 1000)
       await adapter.provideSyncJson(id, JSON.stringify({ changes: {}, ...obj }))
       const result = await adapter.unsafeLoadFromSync(id)
       expect(result).toEqual({ ...obj })
@@ -699,7 +699,7 @@ export default () => {
       )
     ) {
       await expectToRejectWithMessage(
-        adapter.provideSyncJson(0, JSON.stringify({})),
+        adapter.provideSyncJson(0, '{}'),
         'provideSyncJson unavailable',
       )
       return

--- a/src/adapters/compat.js
+++ b/src/adapters/compat.js
@@ -63,9 +63,13 @@ export default class DatabaseAdapterCompat {
     )
   }
 
-  unsafeLoadFromSync(syncPullResultJson: string): Promise<any> {
+  unsafeLoadFromSync(jsonId: number): Promise<any> {
+    return toPromise((callback) => this.underlyingAdapter.unsafeLoadFromSync(jsonId, callback))
+  }
+
+  provideSyncJson(id: number, syncPullResultJson: string): Promise<void> {
     return toPromise((callback) =>
-      this.underlyingAdapter.unsafeLoadFromSync(syncPullResultJson, callback),
+      this.underlyingAdapter.provideSyncJson(id, syncPullResultJson, callback),
     )
   }
 

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -197,8 +197,12 @@ export default class LokiJSAdapter implements DatabaseAdapter {
     )
   }
 
-  unsafeLoadFromSync(syncPullResultJson: string, callback: ResultCallback<any>): void {
+  unsafeLoadFromSync(jsonId: number, callback: ResultCallback<any>): void {
     callback({ error: new Error('unsafeLoadFromSync unavailable') })
+  }
+
+  provideSyncJson(id: number, syncPullResultJson: string, callback: ResultCallback<void>): void {
+    callback({ error: new Error('provideSyncJson unavailable') })
   }
 
   unsafeResetDatabase(callback: ResultCallback<void>): void {

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -290,7 +290,7 @@ export default class SQLiteAdapter implements DatabaseAdapter {
     this._dispatcher.call('batch', [[operation]], callback)
   }
 
-  unsafeLoadFromSync(syncPullResultJson: string, callback: ResultCallback<any>): void {
+  unsafeLoadFromSync(jsonId: number, callback: ResultCallback<any>): void {
     if (this._dispatcherType !== 'jsi') {
       callback({ error: new Error('unsafeLoadFromSync unavailable') })
     }
@@ -299,7 +299,7 @@ export default class SQLiteAdapter implements DatabaseAdapter {
     const { schema } = this
     this._dispatcher.call(
       'unsafeLoadFromSync',
-      [syncPullResultJson, schema, encodeDropIndices(schema), encodeCreateIndices(schema)],
+      [jsonId, schema, encodeDropIndices(schema), encodeCreateIndices(schema)],
       (result) =>
         callback(
           mapValue(
@@ -309,6 +309,14 @@ export default class SQLiteAdapter implements DatabaseAdapter {
           ),
         ),
     )
+  }
+
+  provideSyncJson(id: number, syncPullResultJson: string, callback: ResultCallback<void>): void {
+    if (this._dispatcherType !== 'jsi') {
+      callback({ error: new Error('provideSyncJson unavailable') })
+    }
+
+    this._dispatcher.call('provideSyncJson', [id, syncPullResultJson], callback)
   }
 
   unsafeResetDatabase(callback: ResultCallback<void>): void {

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -293,6 +293,7 @@ export default class SQLiteAdapter implements DatabaseAdapter {
   unsafeLoadFromSync(jsonId: number, callback: ResultCallback<any>): void {
     if (this._dispatcherType !== 'jsi') {
       callback({ error: new Error('unsafeLoadFromSync unavailable') })
+      return
     }
 
     const { encodeDropIndices, encodeCreateIndices } = require('./encodeSchema')
@@ -314,6 +315,7 @@ export default class SQLiteAdapter implements DatabaseAdapter {
   provideSyncJson(id: number, syncPullResultJson: string, callback: ResultCallback<void>): void {
     if (this._dispatcherType !== 'jsi') {
       callback({ error: new Error('provideSyncJson unavailable') })
+      return
     }
 
     this._dispatcher.call('provideSyncJson', [id, syncPullResultJson], callback)

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -295,15 +295,19 @@ export default class SQLiteAdapter implements DatabaseAdapter {
       callback({ error: new Error('unsafeLoadFromSync unavailable') })
     }
 
-    // TODO: Recreate indices
-    this._dispatcher.call('unsafeLoadFromSync', [syncPullResultJson, this.schema], (result) =>
-      callback(
-        mapValue(
-          // { key: JSON.stringify(value) } -> { key: value }
-          (residualValues) => mapObj((values) => JSON.parse(values), residualValues),
-          result,
+    const { encodeDropIndices, encodeCreateIndices } = require('./encodeSchema')
+    const { schema } = this
+    this._dispatcher.call(
+      'unsafeLoadFromSync',
+      [syncPullResultJson, schema, encodeDropIndices(schema), encodeCreateIndices(schema)],
+      (result) =>
+        callback(
+          mapValue(
+            // { key: JSON.stringify(value) } -> { key: value }
+            (residualValues) => mapObj((values) => JSON.parse(values), residualValues),
+            result,
+          ),
         ),
-      ),
     )
   }
 

--- a/src/adapters/sqlite/makeDispatcher/index.native.js
+++ b/src/adapters/sqlite/makeDispatcher/index.native.js
@@ -55,6 +55,9 @@ class SqliteJsiDispatcher implements SqliteDispatcher {
     } else if (methodName === 'batch') {
       methodName = 'batchJSON'
       args = [JSON.stringify(args[0])]
+    } else if (methodName === 'provideSyncJson') {
+      fromPromise(DatabaseBridge.provideSyncJson(...args), callback)
+      return
     }
 
     try {

--- a/src/adapters/sqlite/type.js
+++ b/src/adapters/sqlite/type.js
@@ -66,6 +66,7 @@ export type SqliteDispatcherMethod =
   | 'count'
   | 'batch'
   | 'unsafeLoadFromSync'
+  | 'provideSyncJson'
   | 'unsafeResetDatabase'
   | 'getLocal'
 

--- a/src/adapters/type.js
+++ b/src/adapters/type.js
@@ -56,8 +56,11 @@ export interface DatabaseAdapter {
     callback: ResultCallback<void>,
   ): void;
 
-  // Unsafely adds records from a serialized (json) SyncPullResult
-  unsafeLoadFromSync(syncPullResultJson: string, callback: ResultCallback<any>): void;
+  // Unsafely adds records from a serialized (json) SyncPullResult provided earlier via native API
+  unsafeLoadFromSync(jsonId: number, callback: ResultCallback<any>): void;
+
+  // Provides JSON for use by unsafeLoadFromSync
+  provideSyncJson(id: number, syncPullResultJson: string, callback: ResultCallback<void>): void;
 
   // Destroys the whole database, its schema, indexes, everything.
   unsafeResetDatabase(callback: ResultCallback<void>): void;


### PR DESCRIPTION
Taking Part 6 the extra mile.

The idea is that if we're processing the entire sync JSON in C++, why the heck are we pushing it from native networking code, to JS code, and then back to C++? On iOS, it's not _that_ big of a deal, but on Android, the cost of bridging between JVM and JS is significant, and I saw a nice performance bump when providing JSON from native to native, skipping JS altogether.

Also, a significant decrease in peak memory usage - also a very big deal on Android. Note that previously a 50MB JSON might have been copied multiple times before being used and freed -- and ballooned because JS is dumb UTF-16, which doubles the in-memory size.

So this PR introduces a native API that developers can use to `provide` a sync JSON with some unique id (a sequentially incrementing or a random number is ok), and then from JS, call unsafeLoadFromSync providing that ID.

For testing (and for less native-savvy OSS users), there's a JS api that you can call with a string to `provideSyncJson` - that then calls the native API. So there's a bunch of glue code, but it's all fairly straightforward.

One quirk of this implementation is that the management code for "provided sync JSONs" is implemented per-platform. The reason why is that native code will produce an NSData* on iOS or a byte[] on Android with the json - so to make this value usable until it's used, we either have to copy it (bad - memory usage, performance), or hold on to the platform native reference for as long as we need the data. I chose the latter. This way we can use the underlying raw data copy-free and let the platform do the final memory management.

Additionally, I added the recreate indices performance optimization here, and some extra tests and fixes.