### PR TITLE
Allow different id generator per schema

### DIFF
--- a/src/RawRecord/index.js
+++ b/src/RawRecord/index.js
@@ -83,7 +83,7 @@ export function sanitizedRaw(dirtyRaw: DirtyRaw, tableSchema: TableSchema): RawR
     raw._status = isValidStatus(_status) ? _status : 'created'
     raw._changed = typeof _changed === 'string' ? _changed : ''
   } else {
-    raw.id = randomId()
+    raw.id = randomId(tableSchema.name)
     raw._status = 'created'
     raw._changed = ''
   }


### PR DESCRIPTION
Currently our tables use BigInt as id, and we use `setGenerator` to generate it ourselves. And now we'd like to use uuid as id on some tables, but `setGenerator` doesn't allow generating different ids per schema. I think solution to this would be passing schema name to randomid's generator. If you think that's the right approach, I'll add more code to this PR finalizing the feature.