### PR TITLE
add missing cassert import

### DIFF
--- a/native/android-jsi/src/main/cpp/DatabasePlatformAndroid.cpp
+++ b/native/android-jsi/src/main/cpp/DatabasePlatformAndroid.cpp
@@ -2,6 +2,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <sqlite3.h>
+#include <cassert>
 
 #include "DatabasePlatform.h"
 #include "DatabasePlatformAndroid.h"


### PR DESCRIPTION
without this import i am getting that kind of errors while trying to build on android with jsi enabled:
`node_modules/@nozbe/watermelondb/native/android-jsi/src/main/cpp/DatabasePlatformAndroid.cpp:113:5: error: use of undeclared identifier 'assert'`

with this import it works well