### PR TITLE
Add link to Laravel Watermelon package

### DIFF
--- a/docs-master/Advanced/Sync.md
+++ b/docs-master/Advanced/Sync.md
@@ -449,6 +449,7 @@ Note that those are not maintained by WatermelonDB, and we make no endorsements 
 
 - [How to Build WatermelonDB Sync Backend in Elixir](https://fahri.id/posts/how-to-build-watermelondb-sync-backend-in-elixir/)
 - [Firemelon](https://github.com/AliAllaf/firemelon)
+- [Laravel Watermelon](https://github.com/nathanheffley/laravel-watermelon)
 - Did you make one? Please contribute a link!
 
 ## Current Sync limitations

--- a/docs/Advanced/Sync.html
+++ b/docs/Advanced/Sync.html
@@ -589,6 +589,7 @@ This shape MAY be different if negotiated with the frontend (however, frontend-s
 <ul>
 <li><a href="https://fahri.id/posts/how-to-build-watermelondb-sync-backend-in-elixir/">How to Build WatermelonDB Sync Backend in Elixir</a></li>
 <li><a href="https://github.com/AliAllaf/firemelon">Firemelon</a></li>
+<li><a href="https://github.com/nathanheffley/laravel-watermelon">Laravel Watermelon</a></li>
 <li>Did you make one? Please contribute a link!</li>
 </ul>
 <h2 id="current-sync-limitations"><a class="header" href="#current-sync-limitations">Current Sync limitations</a></h2>

--- a/docs/Advanced/Sync.html
+++ b/docs/Advanced/Sync.html
@@ -589,7 +589,6 @@ This shape MAY be different if negotiated with the frontend (however, frontend-s
 <ul>
 <li><a href="https://fahri.id/posts/how-to-build-watermelondb-sync-backend-in-elixir/">How to Build WatermelonDB Sync Backend in Elixir</a></li>
 <li><a href="https://github.com/AliAllaf/firemelon">Firemelon</a></li>
-<li><a href="https://github.com/nathanheffley/laravel-watermelon">Laravel Watermelon</a></li>
 <li>Did you make one? Please contribute a link!</li>
 </ul>
 <h2 id="current-sync-limitations"><a class="header" href="#current-sync-limitations">Current Sync limitations</a></h2>


### PR DESCRIPTION
[Laravel Watermelon](https://github.com/nathanheffley/laravel-watermelon) is a Composer (PHP) package that provides an easy way to implement an endpoint to your [Laravel](https://github.com/laravel/laravel) project.

Currently, it only provides somewhat rudimentary sync functionality, but I am actively implementing the rest of the major features. Stuff left to do:

1) More robust authorization. There is a way to restrict users from viewing/updating/deleting records based on whatever authorization method you want, but if a user is authorized to see a record they can update any fields or delete the record. Per-field authorization and authorizing create/update/delete still needs implemented.

2) Schema Versioning is not implemented yet.

3) Migrations are not implemented yet.

So needless to say this package is still V1. I am hopeful its inclusion could still be valuable as a starting point for others to implement their own endpoint in other languages, and perhaps Watermelon DB users interested in Laravel could contribute to some of these missing features, but I totally understand if only fully-featured implementations are desired for this section.