### PR TITLE
Fixes typescript annotations in `src/Collection` and `src/adapters/sqlite`

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -20,5 +20,6 @@
 ### Fixes
 
 - Fixes an issue when using Headless JS on Android with JSI mode enabled - pass `usesExclusiveLocking: true` to SQLiteAdapter to enable
+- Fixes Typescript annotations for Collection and adapters/sqlite
 
 ### Internal

--- a/src/Collection/index.d.ts
+++ b/src/Collection/index.d.ts
@@ -4,9 +4,10 @@ declare module '@nozbe/watermelondb/Collection' {
   import { Class } from '@nozbe/watermelondb/utils/common'
   import { Observable, Subject } from 'rxjs'
 
+  type CollectionChangeType = 'created' | 'updated' | 'destroyed'
   export interface CollectionChange<Record extends Model> {
     record: Record
-    isDestroyed: boolean
+    type: CollectionChangeType
   }
 
   export type CollectionChangeSet<Record extends Model> = CollectionChange<Record>[]

--- a/src/adapters/sqlite/index.d.ts
+++ b/src/adapters/sqlite/index.d.ts
@@ -20,11 +20,20 @@ declare module '@nozbe/watermelondb/adapters/sqlite' {
 
   export type SQLiteQuery = [SQL, SQLiteArg[]]
 
+  export type MigrationEvents = {
+    onSuccess: () => void
+    onStart: () => void
+    onError: (error: Error) => void
+  }
+
   export interface SQLiteAdapterOptions {
     dbName?: string
     migrations?: SchemaMigrations
     schema: AppSchema
     jsi?: boolean
+    migrationEvents?: MigrationEvents
+    onSetUpError?: (error: Error) => void
+    usesExclusiveLocking?: boolean
   }
 
   export default class SQLiteAdapter implements DatabaseAdapter {


### PR DESCRIPTION
Actual `@flow` types:

- https://github.com/Nozbe/WatermelonDB/blob/d1e6e210717a3a6e453175f88a21a55f82944530/src/Collection/index.js#L19-L21
- https://github.com/Nozbe/WatermelonDB/blob/192e0f0f969510fa37702f12f5838adfdbd9956e/src/adapters/sqlite/type.js#L12-L33