### PR TITLE
doc: android should specify kotlin version to 1.3.50 or above

### DIFF
--- a/docs-master/Installation.md
+++ b/docs-master/Installation.md
@@ -122,12 +122,12 @@ On RN60+, auto linking should work.
 </details>
 
 <details>
-  <summary>Custom Kotlin Version</summary>
-  Just set ext properties `kotlinVersion` in `android/build.gradle`, and WatermelonDB will use the specified kotlin version.
+  <summary>Custom Kotlin Version ⚠️</summary>
+  Make sure the kotlin version is set to 1.3.50 or above. Just set ext properties `kotlinVersion` in `android/build.gradle`, and WatermelonDB will use the specified kotlin version.
 
   ```gradle
   buildscript {
-      ext.kotlinVersion = '1.3.21'
+      ext.kotlinVersion = '1.3.50'
   }
   ```
 </details>


### PR DESCRIPTION
For more context, check the issue below.
https://github.com/Nozbe/WatermelonDB/issues/1147