### PR TITLE
Database corruption - fix attempt 2137

### DIFF
--- a/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
@@ -8,7 +8,11 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteQuery
 import java.io.File
 
-class Database(private val name: String, private val context: Context, private val openFlags: Int = SQLiteDatabase.CREATE_IF_NECESSARY or SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING) {
+class Database(
+    private val name: String,
+    private val context: Context,
+    private val openFlags: Int = SQLiteDatabase.CREATE_IF_NECESSARY or SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING
+) {
 
     private val db: SQLiteDatabase by lazy {
         // TODO: This SUCKS. Seems like Android doesn't like sqlite `?mode=memory&cache=shared` mode. To avoid random breakages, save the file to /tmp, but this is slow.

--- a/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
+++ b/native/android/src/main/java/com/nozbe/watermelondb/Database.kt
@@ -8,20 +8,21 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteQuery
 import java.io.File
 
-class Database(private val name: String, private val context: Context) {
+class Database(private val name: String, private val context: Context, private val openFlags: Int = SQLiteDatabase.CREATE_IF_NECESSARY or SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING) {
 
     private val db: SQLiteDatabase by lazy {
-        SQLiteDatabase.openOrCreateDatabase(
-                // TODO: This SUCKS. Seems like Android doesn't like sqlite `?mode=memory&cache=shared` mode. To avoid random breakages, save the file to /tmp, but this is slow.
-                // NOTE: This is because Android system SQLite is not compiled with SQLITE_USE_URI=1
-                // issue `PRAGMA cache=shared` query after connection when needed
-                if (name == ":memory:" || name.contains("mode=memory")) {
-                    context.cacheDir.delete()
-                    File(context.cacheDir, name).path
-                } else
-                    // On some systems there is some kind of lock on `/databases` folder ¯\_(ツ)_/¯
-                    context.getDatabasePath("$name.db").path.replace("/databases", ""),
-                null)
+        // TODO: This SUCKS. Seems like Android doesn't like sqlite `?mode=memory&cache=shared` mode. To avoid random breakages, save the file to /tmp, but this is slow.
+        // NOTE: This is because Android system SQLite is not compiled with SQLITE_USE_URI=1
+        // issue `PRAGMA cache=shared` query after connection when needed
+        val path =
+            if (name == ":memory:" || name.contains("mode=memory")) {
+                context.cacheDir.delete()
+                File(context.cacheDir, name).path
+            } else {
+                // On some systems there is some kind of lock on `/databases` folder ¯\_(ツ)_/¯
+                context.getDatabasePath("$name.db").path.replace("/databases", "")
+            }
+        return@lazy SQLiteDatabase.openDatabase(path, null, openFlags)
     }
 
     var userVersion: Int

--- a/native/shared/DatabaseInstallation.cpp
+++ b/native/shared/DatabaseInstallation.cpp
@@ -258,6 +258,12 @@ void Database::install(jsi::Runtime *runtime) {
                 std::abort();
             }
         });
+        createMethod(rt, adapter, "unsafeClose", 0, [database](jsi::Runtime &rt, const jsi::Value *args) {
+            assert(database->initialized_);
+            database->destroy();
+            database->initialized_ = false;
+            return jsi::Value::undefined();
+        });
 
         return adapter;
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nozbe/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "0.23.1-6",
+  "version": "0.23.1-7",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nozbe/watermelondb",
   "description": "Build powerful React Native and React web apps that scale from hundreds to tens of thousands of records and remain fast",
-  "version": "0.23.1-5",
+  "version": "0.23.1-6",
   "scripts": {
     "build": "NODE_ENV=production node ./scripts/make.js",
     "dev": "NODE_ENV=development node ./scripts/make.js",

--- a/src/adapters/sqlite/makeDispatcher/index.native.js
+++ b/src/adapters/sqlite/makeDispatcher/index.native.js
@@ -63,7 +63,11 @@ class SqliteJsiDispatcher implements SqliteDispatcher {
     }
 
     try {
-      let result = this._db[methodName](...args)
+      const method = this._db[methodName]
+      if (!method) {
+        throw new Error('Cannot run database method because database failed to open')
+      }
+      let result = method(...args)
       // On Android, errors are returned, not thrown - see DatabaseInstallation.cpp
       if (result instanceof Error) {
         throw result


### PR DESCRIPTION
- add the possibility of passing open flags to Database.kt
- add a secret debug hook for all database errors for NT use
- add a more understandable error when running methods on DB fails due to DB not having opened properly (previously this would show a mysterious `.apply` failure)
- add a debug hook for manually closing jsi database from JS