### PR TITLE
Add `setGenerator()` to docs

### DIFF
--- a/docs-master/Advanced/ProTips.md
+++ b/docs-master/Advanced/ProTips.md
@@ -13,3 +13,23 @@
 ## Prepopulating database on native
 
 There's no built-in support for this. One way is to generate a SQLite DB (you can use the the Node SQLite support in 0.19.0-2 pre-release or extract it from an ios/android app), bundle it with the app, and then use a bit of code to check if the DB you're expecting it available, and if not, making a copy of the default DB — before you attempt loading DB from JS side. [See discussion](https://github.com/Nozbe/WatermelonDB/issues/774#issuecomment-667981361)
+
+## Override entity ID generator
+
+You can optionally overide WatermelonDB's id generator with your own custom id generator in order to create specific random id formats (e.g. if UUIDs are used in the backend). In your database index file, pass a function with your custom ID generator to `setGenerator`:
+```
+// Define a custom ID generator.
+function randomString(): string {
+  return 'RANDOM STRING';
+}
+setGenerator(randomString);
+
+// or as anonymous function:
+setGenerator(() => 'RANDOM STRING');
+```
+To get UUIDs specifically, install [uuid](https://github.com/uuidjs/uuid) and then pass their id generator to `setGenerator`:
+```
+import { v4 as uuidv4 } from 'uuid';
+
+setGenerator(() => uuidv4());
+```


### PR DESCRIPTION
`setGenerator` is documented in the changelog but not in the official docs. I copied over the typescript example into the Pro Tips page with an added example for UUID specifically. 