### PR TITLE
feat: expose dbName in adapter

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -14,6 +14,7 @@
 
 - [adapters] Adapter objects can now be distinguished by checking their `static adapterType`
 - [Query] New `Q.includes('foo')` query for case-sensitive exact string includes comparison
+- [adapters] Adapter objects now returns `dbName`
 
 ### Performance
 

--- a/src/adapters/__tests__/commonTests.js
+++ b/src/adapters/__tests__/commonTests.js
@@ -1284,5 +1284,8 @@ export default () => {
       }
     })
   })
+  it('can retrieve dbName', async (adapter, _, { dbName }) => {
+    expect(adapter.dbName).toBe(dbName)
+  })
   return commonTests
 }

--- a/src/adapters/compat.js
+++ b/src/adapters/compat.js
@@ -25,6 +25,10 @@ export default class DatabaseAdapterCompat {
     return this.underlyingAdapter.schema
   }
 
+  get dbName(): ?string {
+    return this.underlyingAdapter._dbName
+  }
+
   get migrations(): ?SchemaMigrations {
     return this.underlyingAdapter.migrations
   }

--- a/src/adapters/compat.js
+++ b/src/adapters/compat.js
@@ -26,7 +26,7 @@ export default class DatabaseAdapterCompat {
   }
 
   get dbName(): ?string {
-    return this.underlyingAdapter._dbName
+    return this.underlyingAdapter.dbName
   }
 
   get migrations(): ?SchemaMigrations {

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -82,12 +82,15 @@ export default class LokiJSAdapter implements DatabaseAdapter {
 
   schema: AppSchema
 
+  _dbName: string
+
   migrations: ?SchemaMigrations
 
   _options: LokiAdapterOptions
 
   constructor(options: LokiAdapterOptions): void {
     this._options = options
+    this._dbName = options.dbName || 'loki'
     const { schema, migrations } = options
 
     const useWebWorker = options.useWebWorker ?? process.env.NODE_ENV !== 'test'

--- a/src/adapters/lokijs/index.js
+++ b/src/adapters/lokijs/index.js
@@ -82,7 +82,7 @@ export default class LokiJSAdapter implements DatabaseAdapter {
 
   schema: AppSchema
 
-  _dbName: string
+  dbName: string
 
   migrations: ?SchemaMigrations
 
@@ -90,7 +90,7 @@ export default class LokiJSAdapter implements DatabaseAdapter {
 
   constructor(options: LokiAdapterOptions): void {
     this._options = options
-    this._dbName = options.dbName || 'loki'
+    this.dbName = options.dbName || 'loki'
     const { schema, migrations } = options
 
     const useWebWorker = options.useWebWorker ?? process.env.NODE_ENV !== 'test'

--- a/src/adapters/lokijs/test.js
+++ b/src/adapters/lokijs/test.js
@@ -9,8 +9,9 @@ import DatabaseAdapterCompat from '../compat'
 describe('LokiJSAdapter (Synchronous / Memory persistence)', () => {
   commonTests().forEach((testCase) => {
     const [name, test] = testCase
-    const dbName = `test${Math.random()}`
+
     it(name, async () => {
+      const dbName = `test${Math.random()}`
       const adapter = new LokiJSAdapter({
         dbName,
         schema: testSchema,

--- a/src/adapters/lokijs/test.js
+++ b/src/adapters/lokijs/test.js
@@ -9,10 +9,10 @@ import DatabaseAdapterCompat from '../compat'
 describe('LokiJSAdapter (Synchronous / Memory persistence)', () => {
   commonTests().forEach((testCase) => {
     const [name, test] = testCase
-
+    const dbName = `test${Math.random()}`
     it(name, async () => {
       const adapter = new LokiJSAdapter({
-        dbName: `test${Math.random()}`,
+        dbName,
         schema: testSchema,
         useWebWorker: false,
         useIncrementalIndexedDB: false,
@@ -20,6 +20,7 @@ describe('LokiJSAdapter (Synchronous / Memory persistence)', () => {
       await test(new DatabaseAdapterCompat(adapter), LokiJSAdapter, {
         useWebWorker: false,
         useIncrementalIndexedDB: false,
+        dbName,
       })
     })
   })

--- a/src/adapters/sqlite/integrationTest.js
+++ b/src/adapters/sqlite/integrationTest.js
@@ -15,9 +15,10 @@ const SQLiteAdapterTest = (spec) => {
     commonTests().forEach((testCase) => {
       const [name, test] = testCase
       spec.it(name, async () => {
+        const dbName = `file:testdb${Math.random()}-${Platform.OS}`
         const adapter = new SQLiteAdapter({ schema: testSchema, jsi: false })
         invariant(adapter._dispatcherType === 'asynchronous', 'this should be asynchronous')
-        await test(new DatabaseAdapterCompat(adapter), SQLiteAdapter, {}, Platform.OS)
+        await test(new DatabaseAdapterCompat(adapter), SQLiteAdapter, { dbName }, Platform.OS)
       })
     })
   })

--- a/src/adapters/sqlite/integrationTest.js
+++ b/src/adapters/sqlite/integrationTest.js
@@ -15,8 +15,8 @@ const SQLiteAdapterTest = (spec) => {
     commonTests().forEach((testCase) => {
       const [name, test] = testCase
       spec.it(name, async () => {
-        const dbName = `file:testdb${Math.random()}-${Platform.OS}`
-        const adapter = new SQLiteAdapter({ schema: testSchema, jsi: false })
+        const dbName = `file:testdb${Math.random()}?mode=memory&cache=shared`
+        const adapter = new SQLiteAdapter({ schema: testSchema, jsi: false, dbName })
         invariant(adapter._dispatcherType === 'asynchronous', 'this should be asynchronous')
         await test(new DatabaseAdapterCompat(adapter), SQLiteAdapter, { dbName }, Platform.OS)
       })

--- a/src/adapters/type.d.ts
+++ b/src/adapters/type.d.ts
@@ -11,6 +11,10 @@ declare module '@nozbe/watermelondb/adapters/type' {
 
   export interface DatabaseAdapter {
     schema: AppSchema
+
+    /** Name of the database. */
+    _dbName?: string
+
     // Fetches given (one) record or null. Should not send raw object if already cached in JS
     find(table: TableName<any>, id: RecordId): Promise<CachedFindResult>
 

--- a/src/adapters/type.d.ts
+++ b/src/adapters/type.d.ts
@@ -13,7 +13,7 @@ declare module '@nozbe/watermelondb/adapters/type' {
     schema: AppSchema
 
     /** Name of the database. */
-    _dbName?: string
+    dbName?: string
 
     // Fetches given (one) record or null. Should not send raw object if already cached in JS
     find(table: TableName<any>, id: RecordId): Promise<CachedFindResult>

--- a/src/adapters/type.js
+++ b/src/adapters/type.js
@@ -26,6 +26,8 @@ export type UnsafeExecuteOperations =
 export interface DatabaseAdapter {
   schema: AppSchema;
 
+  _dbName: string;
+
   migrations: ?SchemaMigrations; // TODO: Not optional
 
   // Fetches given (one) record or null. Should not send raw object if already cached in JS

--- a/src/adapters/type.js
+++ b/src/adapters/type.js
@@ -26,7 +26,7 @@ export type UnsafeExecuteOperations =
 export interface DatabaseAdapter {
   schema: AppSchema;
 
-  _dbName: string;
+  dbName: string;
 
   migrations: ?SchemaMigrations; // TODO: Not optional
 


### PR DESCRIPTION
I have issues with managing several user (and several underlying db - see #1224), to avoid creating too many database I want to check that current one is related to connected user 

What I'm doing right now is:

```
if (
      user.status === 'connected' &&
      // @ts-ignore
      (!dbRef.current || dbRef.current.adapter.underlyingAdapter._dbName !== user.id)
    ) {
      dbRef.current = database(user.id);
    }
```

It's a bit low level and I would like to be able to get dbName directly from adapter 


