### PR TITLE
Fix building error in expo project

### DIFF
--- a/WatermelonDB.podspec
+++ b/WatermelonDB.podspec
@@ -13,7 +13,10 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "9.0", :tvos => "9.0" }
   s.source = { :git => "https://github.com/Nozbe/WatermelonDB.git", :tag => "v#{s.version}" }
   s.source_files = "native/ios/**/*.{h,m,mm,swift,c,cpp}", "native/shared/**/*.{h,c,cpp}"
-  s.public_header_files = 'native/ios/WatermelonDB/SupportingFiles/Bridging.h'
+  s.public_header_files = [
+    'native/ios/WatermelonDB/SupportingFiles/Bridging.h',
+    'native/ios/WatermelonDB/JSIInstaller.h',
+  ]
   s.requires_arc = true
   # simdjson is annoyingly slow without compiler optimization, disable for debugging
   s.compiler_flags = '-Os'

--- a/native/ios/WatermelonDB/SupportingFiles/Bridging.h
+++ b/native/ios/WatermelonDB/SupportingFiles/Bridging.h
@@ -6,12 +6,6 @@
 
 #import <React/RCTBridgeModule.h>
 
-#if __has_include("JSIInstaller.h")
-#import "JSIInstaller.h"
-#else
-#import "../JSIInstaller.h"
-#endif
-
 #if __has_include("DatabaseDeleteHelper.h")
 #import "DatabaseDeleteHelper.h"
 #else


### PR DESCRIPTION
# Why

in expo sdk 44+ project, we opened formal swift integration. for swift to call objective-c functions, sometimes the `#import` format should be done right. learn more from https://github.com/expo/expo/issues/15622#issuecomment-997225774

fix #1237 
fix https://github.com/expo/expo/issues/15986
 
# How

watermelonDB has a call from `DatabaseBridge.swift` to `JSIInstaller.h`. for swift to call objective-c functions, we should make `JSIInstaller.h` as a clang module. this pr moves `JSIInstaller.h` as cocoapods public header and the generated umbrella header will include `JSIInstaller.h` as a clang submodule.

# Test Plan

### expo sdk 44 project

1. expo init sdk44 # select bare
2. yarn add @nozbe/watermelondb
3. patch watermelondb with the pr changes
4. add these to `ios/Podfile`
```
  pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi', :modular_headers => true
  pod 'simdjson', path: '../node_modules/@nozbe/simdjson'
```
4. npx pod-install
5. yarn ios


### react-native 0.66 project

1. npx react-native init RN066 --version 0.66
2. yarn add @nozbe/watermelondb
3. patch watermelondb with the pr changes
4. add these to `ios/Podfile`
```
  pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi', :modular_headers => true
  pod 'simdjson', path: '../node_modules/@nozbe/simdjson'
```
4. npx pod-install
5. yarn ios