### PR TITLE
Add columnArray to TableSchema interface

### DIFF
--- a/src/Schema/index.d.ts
+++ b/src/Schema/index.d.ts
@@ -28,6 +28,7 @@ declare module '@nozbe/watermelondb/Schema' {
   export interface TableSchema {
     name: TableName<any>
     columns: ColumnMap
+    columnArray: ColumnSchema[]
   }
 
   interface TableMap {


### PR DESCRIPTION
`columnArray` exists in Flow, but it's missing in Typescript
https://github.com/Nozbe/WatermelonDB/blob/master/src/Schema/index.js#L32