### PR TITLE
fix(ts): wrong migration arg type for pullChanges method

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -33,5 +33,6 @@
 - [android] Fixed compilation on some setups due to a missing <cassert> import
 - [sync] Fixed marking changes as synced for users that don't keep globally unique (only per-table unique) IDs
 - Fix `Model.experimentalMarkAsDeleted/experimentalDestroyPermanently()` throwing an error in some cases
+- [Typescript] Fixed migration arg in pullChanges
 
 ### Internal

--- a/src/sync/index.d.ts
+++ b/src/sync/index.d.ts
@@ -1,6 +1,13 @@
 declare module '@nozbe/watermelondb/sync' {
-  import { DirtyRaw, RecordId, TableName, Model, Database } from '@nozbe/watermelondb'
-  import { Migration } from '@nozbe/watermelondb/Schema/migrations'
+  import type {
+    DirtyRaw,
+    RecordId,
+    TableName,
+    Model,
+    Database,
+    ColumnName,
+  } from '@nozbe/watermelondb'
+  import type { SchemaVersion } from '@nozbe/watermelondb/Schema'
 
   export type Timestamp = number
 
@@ -13,10 +20,16 @@ declare module '@nozbe/watermelondb/sync' {
 
   export type SyncLocalChanges = { changes: SyncDatabaseChangeSet; affectedRecords: Model[] }
 
+  export type MigrationSyncChanges = {
+    columns: { table: TableName<any>; columns: ColumnName[] }[]
+    from: SchemaVersion
+    table: TableName<any>[]
+  }
+
   export type SyncPullArgs = {
     lastPulledAt: Timestamp | null
     schemaVersion?: number
-    migration?: Migration | null
+    migration?: MigrationSyncChanges | null
   }
   export type SyncPullResult = { changes: SyncDatabaseChangeSet; timestamp: Timestamp }
 


### PR DESCRIPTION
In pullChanges arguments, currently migration is typed as a schema migration (with `toVersion` and `steps` attributes)

That is not consistent with what is actually returned : https://github.com/Nozbe/WatermelonDB/blob/4e7abb5ccbdccc018d657673ccc2c72ae06d0681/src/Schema/migrations/getSyncChanges/index.js#L11