### PR TITLE
fix database method types

### DIFF
--- a/src/Database/index.d.ts
+++ b/src/Database/index.d.ts
@@ -50,14 +50,14 @@ export default class Database {
   // is running at the same time.
   // All actions that modify the database (create, update, delete) must be performed inside of a Writer block
   // See docs for more details and practical guide
-  write<T>(work: (WriterInterface) => Promise<T>, description?: string): Promise<T>;
+  write<T>(work: (writer: WriterInterface) => Promise<T>, description?: string): Promise<T>;
 
   // Enqueues a Reader - a block of code that, when it's running, has a guarantee that no Writer
   // is running at the same time (therefore, the database won't be modified for the duration of Reader's work)
   // See docs for more details and practical guide
-  read<T>(work: (ReaderInterface) => Promise<T>, description?: string): Promise<T>;
+  read<T>(work: (reader: ReaderInterface) => Promise<T>, description?: string): Promise<T>;
 
-  action<T>(work: (WriterInterface) => Promise<T>, description?: string): Promise<T>;
+  action<T>(work: (writer: WriterInterface) => Promise<T>, description?: string): Promise<T>;
 
   // Emits a signal immediately, and on change in any of the passed tables
   withChangesForTables(tables: TableName<any>[]): Observable<CollectionChangeSet<any> | null>;


### PR DESCRIPTION
typescript requires names for params in callback types

<img width="600" alt="Screenshot 2022-08-28 at 3 31 52 AM" src="https://user-images.githubusercontent.com/8132723/187049546-2850a904-6c36-4187-860c-79144915c527.png">
