### PR TITLE
Observe ids

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -14,6 +14,7 @@
 
 - [adapters] Adapter objects can now be distinguished by checking their `static adapterType`
 - [Query] New `Q.includes('foo')` query for case-sensitive exact string includes comparison
+- [Query] New `Q.observeIds()` will return an array of matching record ids, then emits a new array every time it changes
 - [adapters] Adapter objects now returns `dbName`
 - [TypeScript] Add unsafeExecute method
 - [TypeScript] Add localStorage property to Database

--- a/src/Query/index.d.ts
+++ b/src/Query/index.d.ts
@@ -78,6 +78,9 @@ export default class Query<Record extends Model> {
   // Queries database and returns an array with IDs of matching records
   fetchIds(): Promise<RecordId[]>
 
+  // Emits an array of matching record ids, then emits a new array every time it changes
+  observeIds(): Observable<RecordId[]>
+
   // Queries database and returns an array with unsanitized raw results
   // You MUST NOT mutate these objects!
   unsafeFetchRaw(): Promise<any[]>

--- a/src/observation/subscribeToIds/index.d.ts
+++ b/src/observation/subscribeToIds/index.d.ts
@@ -1,0 +1,8 @@
+declare module '@nozbe/watermelondb/observation/observeIds' {
+  import { Model, Query, RecordId } from '@nozbe/watermelondb'
+  import { Observable } from 'rxjs'
+
+  export default function observeIds<Record extends Model>(
+    query: Query<Record>,
+  ): Observable<RecordId[]>
+}

--- a/src/observation/subscribeToIds/index.js
+++ b/src/observation/subscribeToIds/index.js
@@ -1,0 +1,43 @@
+// @flow
+
+import { Observable, switchMap, distinctUntilChanged, throttleTime } from '../../utils/rx'
+import { logError } from '../../utils/common'
+import { toPromise } from '../../utils/fp/Result'
+import { type Unsubscribe } from '../../utils/subscriptions'
+
+import type Query from '../../Query'
+import type Model, { RecordId } from '../../Model'
+
+export default function subscribeToIds<Record: Model>(
+  query: Query<Record>,
+  subscriber: (RecordId[]) => void,
+): Unsubscribe {
+  const { collection } = query
+
+  let unsubscribed = false
+
+  const observeIdsFetch = () => {
+    collection._fetchIds(query, (result) => {
+      if (result.error) {
+        logError(result.error.toString())
+        return
+      }
+
+      const shouldEmit = !unsubscribed
+      shouldEmit && subscriber(result.value)
+    })
+  }
+
+  const unsubscribe = collection.database.experimentalSubscribe(query.allTables, observeIdsFetch, {
+    name: 'subscribeToIds',
+    query,
+    subscriber,
+  })
+
+  observeIdsFetch()
+
+  return () => {
+    unsubscribed = true
+    unsubscribe()
+  }
+}

--- a/src/observation/subscribeToIds/test.js
+++ b/src/observation/subscribeToIds/test.js
@@ -1,0 +1,97 @@
+import * as Q from '../../QueryDescription'
+import { mockDatabase } from '../../__tests__/testModels'
+import subscribeToIds from './index'
+
+const prepareTask = (tasks, { id, isCompleted, position }) =>
+  tasks.prepareCreate((mock) => {
+    mock._raw.id = id
+    mock.position = position
+    mock.isCompleted = isCompleted
+  })
+
+const createTask = async (tasks, { id, isCompleted, position }) => {
+  const task = prepareTask(tasks, { id, isCompleted, position })
+  await tasks.database.batch(task)
+  return task
+}
+
+const updateTask = (task, updater) => task.collection.database.write(() => task.update(updater))
+
+describe('subscribeToIds', () => {
+  it('observes changes to ids', async () => {
+    const { db, tasks } = mockDatabase()
+
+    const query = tasks.query(Q.where('is_completed', true), Q.sortBy('position'))
+
+    // start observing
+    const observer = jest.fn()
+    const unsubscribe = subscribeToIds(query, observer)
+
+    const waitForNextQuery = () => tasks.query().fetch()
+    await waitForNextQuery() // wait for initial query to go through
+
+    expect(observer).toHaveBeenCalledTimes(1)
+    expect(observer).toHaveBeenLastCalledWith([])
+
+    // add matching model
+    const t1 = await db.write(() => createTask(tasks, { id: 'a', isCompleted: true, position: 1 }))
+
+    await waitForNextQuery()
+    expect(observer).toHaveBeenCalledTimes(2)
+    expect(observer).toHaveBeenLastCalledWith(['a'])
+
+    // add many matching models
+    let t2
+    let t3
+    await db.write(() => {
+      t2 = prepareTask(tasks, { id: 'b', isCompleted: true, position: 2 })
+      t3 = prepareTask(tasks, { id: 'c', isCompleted: true, position: 3 })
+      return db.batch(t2, t3)
+    })
+
+    await waitForNextQuery()
+    expect(observer).toHaveBeenCalledTimes(3)
+    expect(observer).toHaveBeenLastCalledWith(['a', 'b', 'c'])
+
+    // position chagne
+    await updateTask(t2, () => {
+      t2.position = 44
+    })
+
+    await waitForNextQuery()
+    expect(observer).toHaveBeenCalledTimes(4)
+    expect(observer).toHaveBeenLastCalledWith(['a', 'c', 'b'])
+
+    // irrelevant chagne
+    await updateTask(t2, () => {
+      t2.name = 'hello'
+    })
+
+    await waitForNextQuery()
+    expect(observer).toHaveBeenCalledTimes(5)
+    expect(observer).toHaveBeenLastCalledWith(['a', 'c', 'b'])
+
+    // remove some
+    await db.write(() => t2.destroyPermanently())
+
+    await waitForNextQuery()
+    expect(observer).toHaveBeenCalledTimes(6)
+    expect(observer).toHaveBeenLastCalledWith(['a', 'c'])
+
+    // change to no longer match
+    await updateTask(t1, () => {
+      t1.isCompleted = false
+    })
+
+    await waitForNextQuery()
+    expect(observer).toHaveBeenCalledTimes(7)
+    expect(observer).toHaveBeenLastCalledWith(['c'])
+
+    // ensure record subscriptions are disposed properly
+    unsubscribe()
+    await updateTask(t3, () => {
+      t3.isCompleted = false
+    })
+    expect(observer).toHaveBeenCalledTimes(7)
+  })
+})

--- a/src/observation/subscribeToIds/test.js
+++ b/src/observation/subscribeToIds/test.js
@@ -68,14 +68,14 @@ describe('subscribeToIds', () => {
     })
 
     await waitForNextQuery()
-    expect(observer).toHaveBeenCalledTimes(5)
+    expect(observer).toHaveBeenCalledTimes(4)
     expect(observer).toHaveBeenLastCalledWith(['a', 'c', 'b'])
 
     // remove some
     await db.write(() => t2.destroyPermanently())
 
     await waitForNextQuery()
-    expect(observer).toHaveBeenCalledTimes(6)
+    expect(observer).toHaveBeenCalledTimes(5)
     expect(observer).toHaveBeenLastCalledWith(['a', 'c'])
 
     // change to no longer match
@@ -84,7 +84,7 @@ describe('subscribeToIds', () => {
     })
 
     await waitForNextQuery()
-    expect(observer).toHaveBeenCalledTimes(7)
+    expect(observer).toHaveBeenCalledTimes(6)
     expect(observer).toHaveBeenLastCalledWith(['c'])
 
     // ensure record subscriptions are disposed properly
@@ -92,6 +92,6 @@ describe('subscribeToIds', () => {
     await updateTask(t3, () => {
       t3.isCompleted = false
     })
-    expect(observer).toHaveBeenCalledTimes(7)
+    expect(observer).toHaveBeenCalledTimes(6)
   })
 })


### PR DESCRIPTION
### Discussed in https://github.com/Nozbe/WatermelonDB/discussions/1381

<div type='discussions-op-text'>

<sup>Originally posted by **zhirzh** August 28, 2022</sup>
An observable equivalent to `fetchIds` that emits ids when records are added or removed. This behaviour can be achieved by chaining `observeCount` with `fetchIds`.

```js
class Query {
  ...
  observeIds(): Promise<RecordId[]> {
    return this.observeCount().pipe(switchMap(() => this.fetchIds()))
  }
}
```

Note that this implementation has followingcaveats:

- requires 2 database queries and data transfers over bridge
- no value is emitted if number of matching records remains unchanged even though matching records changed
</div>