### PR TITLE
add generic interface support for tableSchema function

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -16,3 +16,16 @@ export type Array<Type> = Type[]
 export type $Call<F, T> = any
 
 export type $ReadOnlyArray<T> = T[]
+
+export type RequireKey<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
+
+export type IsOptional<T> = Exclude<T, string | number | boolean> extends never ? false : true
+
+// Assumes that arrays and objects will be stored as json strings
+export type GetType<T> = T extends string
+  ? 'string'
+  : T extends number
+  ? 'number'
+  : T extends boolean
+  ? 'boolean'
+  : 'string'


### PR DESCRIPTION
Added an optional generic for the `tableSchema` function this allows for project using Typescript to show mistakes when creating a schema for example: 

```TypeScript
interface Test {
  name: string;
}

tableSchema<Test>({
  name: 'test',
  columns: [{ name: 'name', type: 'number' }], // Type '"number"' is not assignable to type '"string"'
});
```

Alos forces you to provide `isOptional: true` if the property is nullable 

```TypeScript
interface Test {
  name: string;
  age?: number;
}

tableSchema<Test>({
  name: 'test',
  columns: [
    { name: 'name', type: 'string' },
    { name: 'age', type: 'number' }, // Property 'isOptional' is missing in type ...
  ],
});
```
