### PR TITLE
Replace deprecated jcenter() repo with mavenCentral()

### DIFF
--- a/examples/native/android/build.gradle
+++ b/examples/native/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.3")
@@ -34,7 +34,7 @@ allprojects {
         }
 
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://www.jitpack.io' }
     }
 }

--- a/native/android/build.gradle
+++ b/native/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {

--- a/native/androidTest/build.gradle
+++ b/native/androidTest/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.3.31'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
@@ -26,7 +26,7 @@ allprojects {
     repositories {
         google()
         mavenLocal()
-        jcenter()
+        mavenCentral()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../../node_modules/react-native/android"


### PR DESCRIPTION
JCenter has been deprecated a while and is read-only right now, but it has become an unreliable repository and can cause build failures intermittently from server issues when building without cache. There's been a couple times at least since deprecation that jcenter has had server issues for a full day (as I doubt they're spending much resources maintaining it anymore).

https://blog.gradle.org/jcenter-shutdown

In particular to this project, the `native/android/build.gradle` declaration is the most problematic as apps consuming the lib won't easily be able to override the this buildscript repo declaration. It can be safely replaced with mavenCentral() as the Kotlin plugin you're using it for exists there as well. 