### PR TITLE
fix(doc): wrong import, field reference instead of immutableRelation

### DIFF
--- a/docs-master/Relation.md
+++ b/docs-master/Relation.md
@@ -133,7 +133,7 @@ class Post extends Model {
 ```
 
 ```js
-import { field } from '@nozbe/watermelondb/decorators'
+import { immutableRelation } from '@nozbe/watermelondb/decorators'
 
 class PostAuthor extends Model {
   static table = 'post_authors'

--- a/docs/Relation.html
+++ b/docs/Relation.html
@@ -262,7 +262,7 @@ class Post extends Model {
     .query(Q.on('post_authors', 'post_id', this.id));
 }
 </code></pre>
-<pre><code class="language-js">import { field } from '@nozbe/watermelondb/decorators'
+<pre><code class="language-js">import { immutableRelation } from '@nozbe/watermelondb/decorators'
 
 class PostAuthor extends Model {
   static table = 'post_authors'

--- a/docs/print.html
+++ b/docs/print.html
@@ -1748,7 +1748,7 @@ class Post extends Model {
     .query(Q.on('post_authors', 'post_id', this.id));
 }
 </code></pre>
-<pre><code class="language-js">import { field } from '@nozbe/watermelondb/decorators'
+<pre><code class="language-js">import { immutableRelation } from '@nozbe/watermelondb/decorators'
 
 class PostAuthor extends Model {
   static table = 'post_authors'


### PR DESCRIPTION
In the documentation examples there is an import error. Field reference instead of immutableRelation

[Relation](https://nozbe.github.io/WatermelonDB/Relation.html)

![Screenshot 2022-12-31 at 11 51 26](https://user-images.githubusercontent.com/40393115/210140724-52fd434b-9fd9-461e-b353-252be4e7c35c.png)
