### PR TITLE
fix(sync): Remove records that were created and deleted in the same sync

### DIFF
--- a/src/sync/impl/applyRemote.js
+++ b/src/sync/impl/applyRemote.js
@@ -238,7 +238,7 @@ const unsafeApplyAllRemoteChangesByBatches = (
 // deleted, we need to remove it from created so that the record doesn't end
 // up remaining in the DB.
 function reduceChanges(remoteChanges: SyncDatabaseChangeSet): SyncDatabaseChangeSet {
-  Object.keys(remoteChanges).forEach(tableName => {
+  Object.keys(remoteChanges).forEach((tableName: any) => {
     const changes = remoteChanges[tableName]
 
     changes.created = changes.created.filter(rec => !changes.deleted.includes(rec.id))


### PR DESCRIPTION
Essentially, the problem is that if `SyncDatabaseChangeSet` pulls down an `id` in created/updated that's also in deleted, the current code ends up creating that record anyway (and not deleting it). This makes some syncs (especially ones that start from an empty DB or haven't sync'd in a while) retain records that shouldn't actually be in the DB by the time sync finishes.

This fixes that by removing those records from the changeset before sync code erroneously creates/updates those records.

Note: I was not able to `yarn` this project, even from `master`, because the `npm:` style packages (e.g. npm:expect@24.1.0) don't resolve. Am I doing something wrong?

Tested and verified working in my own app. But I don't know how to test this, or even run automation, given the problem mentioned above. Would appreciate feedback on how to unblock that, and on this PR in general. (I'm a bit surprised this hasn't been reported/observed by others, so there's a fair chance I've simply misunderstood how things are supposed to work in sync).

fixes #1462