### PR TITLE
feat: add types to Model class about fetch method

### DIFF
--- a/src/Model/index.d.ts
+++ b/src/Model/index.d.ts
@@ -112,6 +112,8 @@ export default class Model {
 
   get table(): TableName<this>
 
+  public fetch: () => Promise<this>
+
   // FIX_TS
   // Don't use this directly! Use `collection.create()`
   constructor(collection: Collection<Model>, raw: RawRecord)


### PR DESCRIPTION
This small PR fix the typescript problem when i try to get a relation in some model.

Example code: 

```
async function getUserRelation() {
  const userWorkCenterCollection = database.get<UsuarioCentroTrabalhoModel>(
    'user_work_centers',
  );

  const userWorkCenters = await userWorkCenterCollection
    .query(Q.where('work_center_id', data.value))
    .fetch();

  const user = await userWorkCenters[0].usuario.fetch(); // Here i was receiving a message error that do not have fetch method in Model class

  ...
}
```