### PR TITLE
Added missing schema error

### DIFF
--- a/src/adapters/common.js
+++ b/src/adapters/common.js
@@ -15,6 +15,10 @@ export type DirtyQueryResult = Array<RecordId | DirtyRaw>
 export function validateAdapter(adapter: DatabaseAdapter): void {
   if (process.env.NODE_ENV !== 'production') {
     const { schema, migrations } = adapter
+    if (schema === undefined) {
+      throw new Error('Database schema is undefined. Verify that you defined a schema or that you imported it correctly.');
+    }
+
     // TODO: uncomment when full migrations are shipped
     // invariant(migrations, `Missing migrations`)
     if (migrations) {


### PR DESCRIPTION
This addresses the cryptic onboarding issue caused due to docs giving example of a default import, yet [showing code for a schema with a named export](https://watermelondb.dev/docs/Schema#defining-a-schema):
#527

(obv. fixing the docs would also be nice, but this error is nice to have regardless)