### PR TITLE
fix: changed "Twitter" to "𝕏 (Twitter)" in README.md Author and License Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ If you make or are considering making an app using WatermelonDB, please let us k
 
 **WatermelonDB** was created by [@Nozbe](https://github.com/Nozbe).
 
-**WatermelonDB's** main author and maintainer is [Radek Pietruszewski](https://github.com/radex) ([website](https://radex.io) ⋅ [twitter](https://twitter.com/radexp) ⋅ [engineering posters](https://beamvalley.com))
+**WatermelonDB's** main author and maintainer is [Radek Pietruszewski](https://github.com/radex) ([website](https://radex.io) ⋅ [𝕏 (Twitter)](https://twitter.com/radexp) ⋅ [engineering posters](https://beamvalley.com))
 
 [See all contributors](https://github.com/Nozbe/WatermelonDB/graphs/contributors).
 


### PR DESCRIPTION
changed "Twitter" to "𝕏 (Twitter)"

This fixes https://github.com/Nozbe/WatermelonDB/issues/1698