### PR TITLE
fix: sqlite-node initialize error

### DIFF
--- a/src/adapters/sqlite/sqlite-node/DatabaseBridge.js
+++ b/src/adapters/sqlite/sqlite-node/DatabaseBridge.js
@@ -38,6 +38,9 @@ class DatabaseBridge {
       resolve({ code: 'ok' })
     } catch (error) {
       if (driver && error.type === 'SchemaNeededError') {
+        if (driver.database.instance && driver.database.instance.open) {
+          driver.database.instance.close()
+        }
         this.waiting(tag, driver)
         resolve({ code: 'schema_needed' })
       } else if (driver && error.type === 'MigrationNeededError') {


### PR DESCRIPTION
If this instance is not closed, it will result in the occupation of the database file. 
This leads to calling the `unsafeDestroyEverything` method during `setUpWithSchema`.
Although the connection of the new instance is closed, 
an error `resource busy or locked` still occurs when executing `fs.unlinkSync`.
This fixes #1705 