### PR TITLE
fix:The database connection is not closed during the catch block

### DIFF
--- a/src/adapters/sqlite/sqlite-node/DatabaseBridge.js
+++ b/src/adapters/sqlite/sqlite-node/DatabaseBridge.js
@@ -37,6 +37,9 @@ class DatabaseBridge {
 
       resolve({ code: 'ok' })
     } catch (error) {
+      if (driver.database.instance && driver.database.instance.open) {
+        driver.database.instance.close()
+      }
       if (driver && error.type === 'SchemaNeededError') {
         this.waiting(tag, driver)
         resolve({ code: 'schema_needed' })


### PR DESCRIPTION
If this instance is not closed, it will result in the occupation of the database file.

When subsequent calls to `setUpWithMigrations` or `setUpWithSchema` reach the execution of `unsafeDestroyEverything`, 
even though the connection of the new instance is closed, an error `resource busy or locked` still occurs when executing `fs.unlinkSync`."

This fixes https://github.com/Nozbe/WatermelonDB/issues/1705