### PR TITLE
Push only support

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -2,6 +2,11 @@
 
 ### BREAKING CHANGES
 
+#### 2024-01-17
+
+- SyncPushArgs was renamed to SyncPushChangesArgs to free SyncPushArgs which is now used for push sync.
+- lastPulletAt in pushChanges is no longer forced to be defined
+
 ### Deprecations
 
 ### New features

--- a/src/RawRecord/index.d.ts
+++ b/src/RawRecord/index.d.ts
@@ -11,6 +11,8 @@ export type DirtyRaw = { [key: string]: any }
 type _RawRecord = {
   id: RecordId
   _status: SyncStatus
+  // _changed is used by default pull conflict resolution and determines columns for which local
+  // changes will override remote changes
   _changed: string
 }
 

--- a/src/sync/impl/applyRemote.js
+++ b/src/sync/impl/applyRemote.js
@@ -11,7 +11,6 @@ import type {
   Collection,
   Model,
   TableName,
-  DirtyRaw,
   Query,
   RawRecord,
 } from '../..'
@@ -25,7 +24,7 @@ import type {
   SyncConflictResolver,
   SyncPullStrategy,
 } from '../index'
-import { prepareCreateFromRaw, prepareUpdateFromRaw, recordFromRaw } from './helpers'
+import { prepareCreateFromRaw, prepareUpdateFromRaw, recordFromRaw, validateRemoteRaw } from './helpers'
 
 type ApplyRemoteChangesContext = $Exact<{
   db: Database,
@@ -246,15 +245,6 @@ const getAllRecordsToApply = (
         recordsToApplyRemoteChangesTo(db.get((tableName: any)), changes, context),
       ),
     )(remoteChanges),
-  )
-}
-
-function validateRemoteRaw(raw: DirtyRaw): void {
-  // TODO: I think other code is actually resilient enough to handle illegal _status and _changed
-  // would be best to change that part to a warning - but tests are needed
-  invariant(
-    raw && typeof raw === 'object' && 'id' in raw && !('_status' in raw || '_changed' in raw),
-    `[Sync] Invalid raw record supplied to Sync. Records must be objects, must have an 'id' field, and must NOT have a '_status' or '_changed' fields`,
   )
 }
 

--- a/src/sync/impl/helpers.d.ts
+++ b/src/sync/impl/helpers.d.ts
@@ -1,11 +1,19 @@
 import type { Model, Collection, Database } from '../..'
 import type { RawRecord, DirtyRaw } from '../../RawRecord'
-import type { SyncLog, SyncDatabaseChangeSet, SyncConflictResolver } from '../index'
+import type {
+  SyncLog,
+  SyncDatabaseChangeSet,
+  SyncShouldUpdateRecord,
+  SyncConflictResolver,
+  SyncPushResultSet,
+} from '../index'
 
 // Returns raw record with naive solution to a conflict based on local `_changed` field
 // This is a per-column resolution algorithm. All columns that were changed locally win
 // and will be applied on top of the remote version.
 export function resolveConflict(local: RawRecord, remote: DirtyRaw): DirtyRaw
+
+export function validateRemoteRaw(raw: DirtyRaw): void
 
 export function prepareCreateFromRaw<T extends Model = Model>(
   collection: Collection<T>,
@@ -19,7 +27,11 @@ export function prepareUpdateFromRaw<T extends Model = Model>(
   conflictResolver?: SyncConflictResolver,
 ): T
 
-export function prepareMarkAsSynced<T extends Model = Model>(record: T): T
+export function prepareMarkAsSynced<T extends Model = Model>(
+  record: T,
+  pushConflictResolver?: SyncConflictResolver,
+  remoteDirtyRaw?: DirtyRaw,
+): T
 
 export function ensureSameDatabase(database: Database, initialResetCount: number): void
 

--- a/src/sync/impl/helpers.js
+++ b/src/sync/impl/helpers.js
@@ -10,7 +10,6 @@ import type {
   SyncIds,
   SyncLog,
   SyncDatabaseChangeSet,
-  SyncShouldUpdateRecord,
   SyncConflictResolver,
 } from '../index'
 

--- a/src/sync/impl/helpers.js
+++ b/src/sync/impl/helpers.js
@@ -4,9 +4,15 @@ import { values } from '../../utils/fp'
 import areRecordsEqual from '../../utils/fp/areRecordsEqual'
 import { invariant } from '../../utils/common'
 
-import type { Model, Collection, Database, TableName, SyncIds, RecordId } from '../..'
+import type { Model, Collection, Database, TableName, RecordId } from '../..'
 import { type RawRecord, type DirtyRaw, sanitizedRaw } from '../../RawRecord'
-import type { SyncLog, SyncDatabaseChangeSet, SyncConflictResolver } from '../index'
+import type {
+  SyncIds,
+  SyncLog,
+  SyncDatabaseChangeSet,
+  SyncShouldUpdateRecord,
+  SyncConflictResolver,
+} from '../index'
 
 // Returns raw record with naive solution to a conflict based on local `_changed` field
 // This is a per-column resolution algorithm. All columns that were changed locally win
@@ -150,8 +156,10 @@ export const changeSetCount: (SyncDatabaseChangeSet) => number = (changeset) =>
   )
 
 const extractChangeSetIds: (SyncDatabaseChangeSet) => { [TableName<any>]: RecordId[] } = (changeset) =>
-  Object.keys(changeset).reduce((acc, key) => {
+  Object.keys(changeset).reduce((acc: { [TableName<any>]: RecordId[] }, key: string) => {
+    // $FlowFixMe
     const { created, updated, deleted } = changeset[key]
+    // $FlowFixMe
     acc[key] = [
       ...created.map(it => it.id),
       ...updated.map(it => it.id),
@@ -162,22 +170,28 @@ const extractChangeSetIds: (SyncDatabaseChangeSet) => { [TableName<any>]: Record
 
 // Returns all rejected ids and is used when accepted ids are used 
 export const findRejectedIds:
-  (SyncIds, SyncIds, SyncDatabaseChangeSet) => SyncIds =
+  (?SyncIds, ?SyncIds, SyncDatabaseChangeSet) => SyncIds =
     (experimentalRejectedIds, experimentalAcceptedIds, changeset) => {
       const localIds = extractChangeSetIds(changeset)
 
-      const acceptedIdsSets = Object.keys(changeset).reduce((acc, key) => {
-        acc[key] = new Set(experimentalAcceptedIds[key])
-        return acc
+      const acceptedIdsSets = Object.keys(changeset).reduce(
+        (acc: { [TableName<any>]: Set<RecordId> }, key: string) => {
+          // $FlowFixMe
+          acc[key] = new Set(experimentalAcceptedIds[key])
+          return acc
       }, {})
 
-      return Object.keys(changeset).reduce((acc, key) => {
+      return Object.keys(changeset).reduce((acc: { [TableName<any>]: RecordId[] }, key: string) => {
         const rejectedIds = [
+          // $FlowFixMe
           ...(experimentalRejectedIds ? experimentalRejectedIds[key] || [] : []),
+          // $FlowFixMe
           ...(localIds[key] || []),
+          // $FlowFixMe
         ].filter(it => !acceptedIdsSets[key].has(it))
         
         if (rejectedIds.length > 0) {
+          // $FlowFixMe
           acc[key] = rejectedIds
         }
         return acc

--- a/src/sync/impl/markAsSynced.d.ts
+++ b/src/sync/impl/markAsSynced.d.ts
@@ -1,6 +1,6 @@
 import type { Database, Model, TableName } from '../..'
 
-import type { SyncLocalChanges, SyncIds } from '../index'
+import type { SyncLocalChanges, SyncIds, SyncConflictResolver, SyncPushResultSet } from '../index'
 
 export default function markLocalChangesAsSynced(
   db: Database,
@@ -8,4 +8,6 @@ export default function markLocalChangesAsSynced(
   allowOnlyAcceptedIds: boolean,
   rejectedIds?: SyncIds,
   allAcceptedIds?: SyncIds,
+  pushConflictResolver?: SyncConflictResolver,
+  remoteDirtyRaws?: SyncPushResultSet,
 ): Promise<void>

--- a/src/sync/impl/markAsSynced.d.ts
+++ b/src/sync/impl/markAsSynced.d.ts
@@ -1,9 +1,11 @@
 import type { Database, Model, TableName } from '../..'
 
-import type { SyncLocalChanges, SyncRejectedIds } from '../index'
+import type { SyncLocalChanges, SyncIds } from '../index'
 
 export default function markLocalChangesAsSynced(
   db: Database,
   syncedLocalChanges: SyncLocalChanges,
-  rejectedIds?: SyncRejectedIds,
+  allowOnlyAcceptedIds: boolean,
+  rejectedIds?: SyncIds,
+  allAcceptedIds?: SyncIds,
 ): Promise<void>

--- a/src/sync/impl/markAsSynced.js
+++ b/src/sync/impl/markAsSynced.js
@@ -30,7 +30,7 @@ const recordsToMarkAsSynced = (
         )
         return
       }
-      const isAccepted = !allAcceptedIds || !allowOnlyAcceptedIds || acceptedIds.has(id);
+      const isAccepted = !allAcceptedIds || !allowOnlyAcceptedIds || acceptedIds.has(id)
       if (areRecordsEqual(record._raw, raw) && !rejectedIds.has(id) && isAccepted) {
         syncedRecords.push(record)
       }
@@ -44,7 +44,7 @@ const destroyDeletedRecords = (
   { changes }: SyncLocalChanges,
   allowOnlyAcceptedIds: boolean,
   allRejectedIds: SyncIds,
-  allAcceptedIds?: ?SyncIds,
+  allAcceptedIds: SyncIds,
 ): Promise<any>[] =>
   Object.keys(changes).map((_tableName) => {
     const tableName: TableName<any> = (_tableName: any)

--- a/src/sync/impl/markAsSynced.js
+++ b/src/sync/impl/markAsSynced.js
@@ -4,8 +4,8 @@ import areRecordsEqual from '../../utils/fp/areRecordsEqual'
 import { logError } from '../../utils/common'
 import type { Database, Model, TableName } from '../..'
 
-import { prepareMarkAsSynced } from './helpers'
-import type { SyncLocalChanges, SyncIds } from '../index'
+import { prepareMarkAsSynced, validateRemoteRaw } from './helpers'
+import type { SyncLocalChanges, SyncIds, SyncConflictResolver, SyncPushResultSet } from '../index'
 
 const recordsToMarkAsSynced = (
   { changes, affectedRecords }: SyncLocalChanges,
@@ -61,13 +61,27 @@ export default function markLocalChangesAsSynced(
   allowOnlyAcceptedIds: boolean,
   rejectedIds?: ?SyncIds,
   allAcceptedIds?: ?SyncIds,
+  pushConflictResolver?: ?SyncConflictResolver,
+  remoteDirtyRaws?: ?SyncPushResultSet,
 ): Promise<void> {
   return db.write(async () => {
     // update and destroy records concurrently
     await Promise.all([
       db.batch(
         recordsToMarkAsSynced(syncedLocalChanges, allowOnlyAcceptedIds, rejectedIds || {}, 
-          allAcceptedIds || {}).map(prepareMarkAsSynced),
+          allAcceptedIds || {}).map(it => {
+            // if pushConflictResolver is not set, lookup by remote raws isn't necessary
+            if (!pushConflictResolver || !remoteDirtyRaws) {
+              return prepareMarkAsSynced(it, null, null)
+            }
+            const collectionRemoteDirtyRaws = remoteDirtyRaws[it.collection.modelClass.table]
+            if (!collectionRemoteDirtyRaws) {
+              return prepareMarkAsSynced(it, null, null)
+            }
+            const remoteDirtyRaw = collectionRemoteDirtyRaws.find(dirtyRaw => dirtyRaw.id === it.id)
+            remoteDirtyRaw && validateRemoteRaw(remoteDirtyRaw)
+            return prepareMarkAsSynced(it, pushConflictResolver, remoteDirtyRaw)
+          }),
       ),
       ...destroyDeletedRecords(db, syncedLocalChanges, allowOnlyAcceptedIds, rejectedIds || {}, 
         allAcceptedIds || {}),

--- a/src/sync/impl/synchronize.d.ts
+++ b/src/sync/impl/synchronize.d.ts
@@ -10,6 +10,7 @@ export default function synchronize({
   log,
   conflictResolver,
   pushShouldConfirmOnlyAccepted,
+  pushConflictResolver,
   _unsafeBatchPerCollection,
   unsafeTurbo,
 }: SyncArgs): Promise<void>

--- a/src/sync/impl/synchronize.d.ts
+++ b/src/sync/impl/synchronize.d.ts
@@ -1,4 +1,4 @@
-import type { SyncArgs } from '../index'
+import type { SyncArgs, OptimisticSyncPushArgs } from '../index'
 
 export default function synchronize({
   database,
@@ -14,3 +14,11 @@ export default function synchronize({
   _unsafeBatchPerCollection,
   unsafeTurbo,
 }: SyncArgs): Promise<void>
+
+export function optimisticSyncPush({
+  database,
+  pushChanges,
+  log,
+  pushShouldConfirmOnlyAccepted,
+  pushConflictResolver,
+}: OptimisticSyncPushArgs): Promise<void>

--- a/src/sync/impl/synchronize.d.ts
+++ b/src/sync/impl/synchronize.d.ts
@@ -9,6 +9,7 @@ export default function synchronize({
   migrationsEnabledAtVersion,
   log,
   conflictResolver,
+  pushShouldConfirmOnlyAccepted,
   _unsafeBatchPerCollection,
   unsafeTurbo,
 }: SyncArgs): Promise<void>

--- a/src/sync/impl/synchronize.js
+++ b/src/sync/impl/synchronize.js
@@ -25,6 +25,7 @@ export default async function synchronize({
   log,
   conflictResolver,
   pushShouldConfirmOnlyAccepted,
+  pushConflictResolver,
   _unsafeBatchPerCollection,
   unsafeTurbo,
 }: SyncArgs): Promise<void> {
@@ -142,7 +143,8 @@ export default async function synchronize({
 
       ensureSameDatabase(database, resetCount)
       await markLocalChangesAsSynced(database, localChanges, pushShouldConfirmOnlyAccepted || false,
-        pushResult.experimentalRejectedIds, pushResult.experimentalAcceptedIds)
+        pushResult.experimentalRejectedIds, pushResult.experimentalAcceptedIds, pushConflictResolver,
+        pushResult.pushResultSet)
       log && (log.phase = 'marked local changes as synced')
     }
   } else {

--- a/src/sync/impl/synchronize.js
+++ b/src/sync/impl/synchronize.js
@@ -12,7 +12,52 @@ import {
   getMigrationInfo,
 } from './index'
 import { ensureSameDatabase, isChangeSetEmpty, changeSetCount, findRejectedIds } from './helpers'
-import type { SyncArgs, Timestamp, SyncPullStrategy } from '../index'
+import type {
+  SyncArgs,
+  OptimisticSyncPushArgs,
+  SyncPushArgs,
+  Timestamp,
+  SyncPullStrategy,
+} from '../index'
+
+async function syncPush({
+  database,
+  pushChanges,
+  log,
+  pushShouldConfirmOnlyAccepted,
+  pushConflictResolver,
+  resetCount,
+  lastPulledAt,
+}: SyncPushArgs): Promise<void> {
+  if (pushChanges) {
+    log && (log.phase = 'ready to fetch local changes')
+
+    const localChanges = await fetchLocalChanges(database)
+    log && (log.localChangeCount = changeSetCount(localChanges.changes))
+    log && (log.phase = 'fetched local changes')
+
+    ensureSameDatabase(database, resetCount)
+    if (!isChangeSetEmpty(localChanges.changes)) {
+      log && (log.phase = 'ready to push')
+      const pushResult =
+        (await pushChanges({ changes: localChanges.changes, lastPulledAt })) || {}
+      log && (log.phase = 'pushed')
+      log && (log.rejectedIds = pushResult.experimentalRejectedIds)
+      if (log && pushShouldConfirmOnlyAccepted) {
+        log.rejectedIds = findRejectedIds(pushResult.experimentalRejectedIds, 
+          pushResult.experimentalAcceptedIds, localChanges.changes)
+      }
+
+      ensureSameDatabase(database, resetCount)
+      await markLocalChangesAsSynced(database, localChanges, pushShouldConfirmOnlyAccepted || false,
+        pushResult.experimentalRejectedIds, pushResult.experimentalAcceptedIds, pushConflictResolver,
+        pushResult.pushResultSet)
+      log && (log.phase = 'marked local changes as synced')
+    }
+  } else {
+    log && (log.phase = 'pushChanges not defined')
+  }
+}
 
 export default async function synchronize({
   database,
@@ -122,35 +167,39 @@ export default async function synchronize({
   }, 'sync-synchronize-apply')
 
   // push phase
-  if (pushChanges) {
-    log && (log.phase = 'ready to fetch local changes')
-
-    const localChanges = await fetchLocalChanges(database)
-    log && (log.localChangeCount = changeSetCount(localChanges.changes))
-    log && (log.phase = 'fetched local changes')
-
-    ensureSameDatabase(database, resetCount)
-    if (!isChangeSetEmpty(localChanges.changes)) {
-      log && (log.phase = 'ready to push')
-      const pushResult =
-        (await pushChanges({ changes: localChanges.changes, lastPulledAt: newLastPulledAt })) || {}
-      log && (log.phase = 'pushed')
-      log && (log.rejectedIds = pushResult.experimentalRejectedIds)
-      if (log && pushShouldConfirmOnlyAccepted) {
-        log.rejectedIds = findRejectedIds(pushResult.experimentalRejectedIds, 
-          pushResult.experimentalAcceptedIds, localChanges.changes)
-      }
-
-      ensureSameDatabase(database, resetCount)
-      await markLocalChangesAsSynced(database, localChanges, pushShouldConfirmOnlyAccepted || false,
-        pushResult.experimentalRejectedIds, pushResult.experimentalAcceptedIds, pushConflictResolver,
-        pushResult.pushResultSet)
-      log && (log.phase = 'marked local changes as synced')
-    }
-  } else {
-    log && (log.phase = 'pushChanges not defined')
-  }
+  await syncPush({
+    database,
+    pushChanges,
+    log,
+    pushShouldConfirmOnlyAccepted,
+    pushConflictResolver,
+    resetCount,
+    lastPulledAt: newLastPulledAt,
+  })
 
   log && (log.finishedAt = new Date())
   log && (log.phase = 'done')
+}
+
+export async function optimisticSyncPush({
+  database,
+  pushChanges,
+  log,
+  pushShouldConfirmOnlyAccepted,
+  pushConflictResolver,
+}: OptimisticSyncPushArgs): Promise<void> {
+  const resetCount = database._resetCount
+
+  const lastPulledAt = await getLastPulledAt(database)
+  log && (log.lastPulledAt = lastPulledAt)
+
+  await syncPush({
+    database,
+    pushChanges,
+    log,
+    pushShouldConfirmOnlyAccepted,
+    pushConflictResolver,
+    resetCount,
+    lastPulledAt,
+  })
 }

--- a/src/sync/impl/synchronize.js
+++ b/src/sync/impl/synchronize.js
@@ -141,7 +141,7 @@ export default async function synchronize({
       }
 
       ensureSameDatabase(database, resetCount)
-      await markLocalChangesAsSynced(database, localChanges, pushShouldConfirmOnlyAccepted,
+      await markLocalChangesAsSynced(database, localChanges, pushShouldConfirmOnlyAccepted || false,
         pushResult.experimentalRejectedIds, pushResult.experimentalAcceptedIds)
       log && (log.phase = 'marked local changes as synced')
     }

--- a/src/sync/index.d.ts
+++ b/src/sync/index.d.ts
@@ -29,9 +29,14 @@ export type SyncPullResult =
 
 export type SyncRejectedIds = { [tableName: TableName<any>]: RecordId[] }
 
+export type SyncAcceptedIds = { [tableName: TableName<any>]: RecordId[] }
+
 export type SyncPushArgs = $Exact<{ changes: SyncDatabaseChangeSet; lastPulledAt: Timestamp }>
 
-export type SyncPushResult = $Exact<{ experimentalRejectedIds?: SyncRejectedIds }>
+export type SyncPushResult = $Exact<{
+  experimentalRejectedIds?: SyncRejectedIds,
+  experimentalAcceptedIds?: SyncAcceptedIds,
+}>
 
 type SyncConflict = $Exact<{ local: DirtyRaw; remote: DirtyRaw; resolved: DirtyRaw }>
 export type SyncLog = {

--- a/src/sync/index.d.ts
+++ b/src/sync/index.d.ts
@@ -29,6 +29,8 @@ export type SyncPullResult =
 
 export type SyncIds = { [tableName: TableName<any>]: RecordId[] }
 
+export type SyncRejectedIds = SyncIds
+
 export type SyncPushArgs = $Exact<{ changes: SyncDatabaseChangeSet; lastPulledAt: Timestamp }>
 
 export type SyncPushResult = $Exact<{

--- a/src/sync/index.d.ts
+++ b/src/sync/index.d.ts
@@ -31,7 +31,7 @@ export type SyncIds = { [tableName: TableName<any>]: RecordId[] }
 
 export type SyncRejectedIds = SyncIds
 
-export type SyncPushArgs = $Exact<{ changes: SyncDatabaseChangeSet; lastPulledAt: Timestamp }>
+export type SyncPushChangesArgs = $Exact<{ changes: SyncDatabaseChangeSet; lastPulledAt: Timestamp }>
 
 export type SyncPushResultSet = { [tableName: TableName<any>]: DirtyRaw[] }
 
@@ -64,20 +64,10 @@ export type SyncConflictResolver = (
   resolved: DirtyRaw,
 ) => DirtyRaw
 
-export type SyncArgs = $Exact<{
+export type OptimisticSyncPushArgs = $Exact<{
   database: Database;
-  pullChanges: (_: SyncPullArgs) => Promise<SyncPullResult>;
-  pushChanges?: (_: SyncPushArgs) => Promise<SyncPushResult | undefined | void>;
-  // version at which support for migration syncs was added - the version BEFORE first syncable migration
-  migrationsEnabledAtVersion?: SchemaVersion;
-  sendCreatedAsUpdated?: boolean;
+  pushChanges?: (_: SyncPushChangesArgs) => Promise<SyncPushResult | undefined | void>;
   log?: SyncLog;
-  // Advanced (unsafe) customization point. Useful when you have subtle invariants between multiple
-  // columns and want to have them updated consistently, or to implement partial sync
-  // It's called for every record being updated locally, so be sure that this function is FAST.
-  // If you don't want to change default behavior for a given record, return `resolved` as is
-  // Note that it's safe to mutate `resolved` object, so you can skip copying it for performance.
-  conflictResolver?: SyncConflictResolver;
   // experimental customization that will cause to only set records as synced if we return id.
   // This will in turn cause all records to be re-pushed if id wasn't returned. This allows to
   // "whitelisting" ids instead of "blacklisting" (rejectedIds) so that there is less chance that
@@ -89,6 +79,26 @@ export type SyncArgs = $Exact<{
   // Note that by default _status will be still synced so update if required
   // Note that it's safe to mutate `resolved` object, so you can skip copying it for performance.
   pushConflictResolver?: SyncConflictResolver;
+}>
+
+export type SyncPushArgs = $Exact<{OptimisticSyncPushArgs}> & $Exact<{
+  resetCount: number;
+  lastPulledAt: Timestamp;
+}>
+
+export type SyncArgs = $Exact<{OptimisticSyncPushArgs}> & $Exact<{
+  database: Database;
+  pullChanges: (_: SyncPullArgs) => Promise<SyncPullResult>;
+  // version at which support for migration syncs was added - the version BEFORE first syncable migration
+  migrationsEnabledAtVersion?: SchemaVersion;
+  sendCreatedAsUpdated?: boolean;
+  log?: SyncLog;
+  // Advanced (unsafe) customization point. Useful when you have subtle invariants between multiple
+  // columns and want to have them updated consistently, or to implement partial sync
+  // It's called for every record being updated locally, so be sure that this function is FAST.
+  // If you don't want to change default behavior for a given record, return `resolved` as is
+  // Note that it's safe to mutate `resolved` object, so you can skip copying it for performance.
+  conflictResolver?: SyncConflictResolver;
   // commits changes in multiple batches, and not one - temporary workaround for memory issue
   _unsafeBatchPerCollection?: boolean;
   // Advanced optimization - pullChanges must return syncJson or syncJsonId to be processed by native code.
@@ -108,5 +118,7 @@ export type SyncArgs = $Exact<{
 }>
 
 export function synchronize(args: SyncArgs): Promise<void>
+
+export function optimisticSyncPush(args: OptimisticSyncPushArgs): Promise<void>
 
 export function hasUnsyncedChanges({ database }: $Exact<{ database: Database }>): Promise<boolean>

--- a/src/sync/index.d.ts
+++ b/src/sync/index.d.ts
@@ -27,15 +27,13 @@ export type SyncPullResult =
   | $Exact<{ syncJson: string }>
   | $Exact<{ syncJsonId: number }>
 
-export type SyncRejectedIds = { [tableName: TableName<any>]: RecordId[] }
-
-export type SyncAcceptedIds = { [tableName: TableName<any>]: RecordId[] }
+export type SyncIds = { [tableName: TableName<any>]: RecordId[] }
 
 export type SyncPushArgs = $Exact<{ changes: SyncDatabaseChangeSet; lastPulledAt: Timestamp }>
 
 export type SyncPushResult = $Exact<{
-  experimentalRejectedIds?: SyncRejectedIds,
-  experimentalAcceptedIds?: SyncAcceptedIds,
+  experimentalRejectedIds?: SyncIds,
+  experimentalAcceptedIds?: SyncIds,
 }>
 
 type SyncConflict = $Exact<{ local: DirtyRaw; remote: DirtyRaw; resolved: DirtyRaw }>
@@ -46,7 +44,7 @@ export type SyncLog = {
   migration?: MigrationSyncChanges;
   newLastPulledAt?: number;
   resolvedConflicts?: SyncConflict[];
-  rejectedIds?: SyncRejectedIds;
+  rejectedIds?: SyncIds;
   finishedAt?: Date;
   remoteChangeCount?: number;
   localChangeCount?: number;
@@ -75,6 +73,11 @@ export type SyncArgs = $Exact<{
   // If you don't want to change default behavior for a given record, return `resolved` as is
   // Note that it's safe to mutate `resolved` object, so you can skip copying it for performance.
   conflictResolver?: SyncConflictResolver;
+  // experimental customization that will cause to only set records as synced if we return id.
+  // This will in turn cause all records to be re-pushed if id wasn't returned. This allows to
+  // "whitelisting" ids instead of "blacklisting" (rejectedIds) so that there is less chance that
+  // unpredicted error will cause data loss (when failed data push isn't re-pushed)
+  pushShouldConfirmOnlyAccepted?: boolean;
   // commits changes in multiple batches, and not one - temporary workaround for memory issue
   _unsafeBatchPerCollection?: boolean;
   // Advanced optimization - pullChanges must return syncJson or syncJsonId to be processed by native code.

--- a/src/sync/index.d.ts
+++ b/src/sync/index.d.ts
@@ -33,9 +33,12 @@ export type SyncRejectedIds = SyncIds
 
 export type SyncPushArgs = $Exact<{ changes: SyncDatabaseChangeSet; lastPulledAt: Timestamp }>
 
+export type SyncPushResultSet = { [tableName: TableName<any>]: DirtyRaw[] }
+
 export type SyncPushResult = $Exact<{
   experimentalRejectedIds?: SyncIds,
   experimentalAcceptedIds?: SyncIds,
+  pushResultSet?: SyncPushResultSet,
 }>
 
 type SyncConflict = $Exact<{ local: DirtyRaw; remote: DirtyRaw; resolved: DirtyRaw }>
@@ -80,6 +83,12 @@ export type SyncArgs = $Exact<{
   // "whitelisting" ids instead of "blacklisting" (rejectedIds) so that there is less chance that
   // unpredicted error will cause data loss (when failed data push isn't re-pushed)
   pushShouldConfirmOnlyAccepted?: boolean;
+  // conflict resolver on push side of sync which also requires returned records from backend.
+  // This is also useful for multi-step sync where one must control in which state sync is and if it
+  // must be repeated.
+  // Note that by default _status will be still synced so update if required
+  // Note that it's safe to mutate `resolved` object, so you can skip copying it for performance.
+  pushConflictResolver?: SyncConflictResolver;
   // commits changes in multiple batches, and not one - temporary workaround for memory issue
   _unsafeBatchPerCollection?: boolean;
   // Advanced optimization - pullChanges must return syncJson or syncJsonId to be processed by native code.

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -55,6 +55,8 @@ export type SyncPullResult =
 
 export type SyncIds = { [TableName<any>]: RecordId[] }
 
+export type SyncRejectedIds = SyncIds
+
 export type SyncPushArgs = $Exact<{ changes: SyncDatabaseChangeSet, lastPulledAt: Timestamp }>
 
 export type SyncPushResult = $Exact<{

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -53,11 +53,14 @@ export type SyncPullResult =
   | $Exact<{ syncJson: string }>
   | $Exact<{ syncJsonId: number }>
 
-export type SyncRejectedIds = { [TableName<any>]: RecordId[] }
+export type SyncIds = { [TableName<any>]: RecordId[] }
 
 export type SyncPushArgs = $Exact<{ changes: SyncDatabaseChangeSet, lastPulledAt: Timestamp }>
 
-export type SyncPushResult = $Exact<{ experimentalRejectedIds?: SyncRejectedIds }>
+export type SyncPushResult = $Exact<{
+  experimentalRejectedIds?: SyncIds,
+  experimentalAcceptedIds?: SyncIds,
+}>
 
 type SyncConflict = $Exact<{ local: DirtyRaw, remote: DirtyRaw, resolved: DirtyRaw }>
 export type SyncLog = {
@@ -67,7 +70,7 @@ export type SyncLog = {
   migration?: ?MigrationSyncChanges,
   newLastPulledAt?: number,
   resolvedConflicts?: SyncConflict[],
-  rejectedIds?: SyncRejectedIds,
+  rejectedIds?: SyncIds,
   finishedAt?: Date,
   remoteChangeCount?: number,
   localChangeCount?: number,

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -57,7 +57,7 @@ export type SyncIds = { [TableName<any>]: RecordId[] }
 
 export type SyncRejectedIds = SyncIds
 
-export type SyncPushArgs = $Exact<{ changes: SyncDatabaseChangeSet, lastPulledAt: Timestamp }>
+export type SyncPushChangesArgs = $Exact<{ changes: SyncDatabaseChangeSet, lastPulledAt?: ?Timestamp }>
 
 export type SyncPushResultSet = { [tableName: TableName<any>]: DirtyRaw[] }
 
@@ -83,6 +83,12 @@ export type SyncLog = {
   error?: Error,
 }
 
+export type SyncShouldUpdateRecord = (
+  table: TableName<any>,
+  local: DirtyRaw,
+  remote: DirtyRaw,
+) => boolean
+
 export type SyncConflictResolver = (
   table: TableName<any>,
   local: DirtyRaw,
@@ -90,21 +96,10 @@ export type SyncConflictResolver = (
   resolved: DirtyRaw,
 ) => DirtyRaw
 
-// TODO: JSDoc'ify this
-export type SyncArgs = $Exact<{
-  database: Database,
-  pullChanges: (SyncPullArgs) => Promise<SyncPullResult>,
-  pushChanges?: (SyncPushArgs) => Promise<?SyncPushResult>,
-  // version at which support for migration syncs was added - the version BEFORE first syncable migration
-  migrationsEnabledAtVersion?: SchemaVersion,
-  sendCreatedAsUpdated?: boolean,
-  log?: SyncLog,
-  // Advanced (unsafe) customization point. Useful when you have subtle invariants between multiple
-  // columns and want to have them updated consistently, or to implement partial sync
-  // It's called for every record being updated locally, so be sure that this function is FAST.
-  // If you don't want to change default behavior for a given record, return `resolved` as is
-  // Note that it's safe to mutate `resolved` object, so you can skip copying it for performance.
-  conflictResolver?: SyncConflictResolver,
+export type OptimisticSyncPushArgs = $Exact<{
+  database: Database;
+  pushChanges?: (_: SyncPushChangesArgs) => Promise<SyncPushResult | void>;
+  log?: SyncLog;
   // experimental customization that will cause to only set records as synced if we return id.
   // This will in turn cause all records to be re-pushed if id wasn't returned. This allows to
   // "whitelisting" ids instead of "blacklisting" (rejectedIds) so that there is less chance that
@@ -116,22 +111,48 @@ export type SyncArgs = $Exact<{
   // Note that by default _status will be still synced so update if required
   // Note that it's safe to mutate `resolved` object, so you can skip copying it for performance.
   pushConflictResolver?: SyncConflictResolver;
+}>
+
+export type SyncPushArgs = $Exact<{
+  ...OptimisticSyncPushArgs;
+  resetCount: number;
+  lastPulledAt?: ?Timestamp;
+}>
+
+// TODO: JSDoc'ify this
+export type SyncArgs = $Exact<{
+  ...OptimisticSyncPushArgs;
+  database: Database;
+  pullChanges: (_: SyncPullArgs) => Promise<SyncPullResult>;
+  // version at which support for migration syncs was added - the version BEFORE first syncable migration
+  migrationsEnabledAtVersion?: SchemaVersion;
+  sendCreatedAsUpdated?: boolean;
+  log?: SyncLog;
+  // Advanced (unsafe) customization point. Useful when doing per record conflict resolution and can
+  // determine directly from remote and local if we can keep local.
+  shouldUpdateRecord?: SyncShouldUpdateRecord;
+  // Advanced (unsafe) customization point. Useful when you have subtle invariants between multiple
+  // columns and want to have them updated consistently, or to implement partial sync
+  // It's called for every record being updated locally, so be sure that this function is FAST.
+  // If you don't want to change default behavior for a given record, return `resolved` as is
+  // Note that it's safe to mutate `resolved` object, so you can skip copying it for performance.
+  conflictResolver?: SyncConflictResolver;
   // commits changes in multiple batches, and not one - temporary workaround for memory issue
-  _unsafeBatchPerCollection?: boolean,
+  _unsafeBatchPerCollection?: boolean;
   // Advanced optimization - pullChanges must return syncJson or syncJsonId to be processed by native code.
   // This can only be used on initial (login) sync, not for incremental syncs.
   // This can only be used with SQLiteAdapter with JSI enabled.
   // The exact API may change between versions of WatermelonDB.
   // See documentation for more details.
-  unsafeTurbo?: boolean,
-  // Called after changes are pulled with whatever was returned by pullChanges, minus `changes`. Useful
+  unsafeTurbo?: boolean;
+  // Called after pullChanges with whatever was returned by pullChanges, minus `changes`. Useful
   // when using turbo mode
-  onDidPullChanges?: (Object) => Promise<void>,
+  onDidPullChanges?: (_: Object) => Promise<void>;
   // Called after pullChanges is done, but before these changes are applied. Some stats about the pulled
   // changes are passed as arguments. An advanced user can use this for example to show some UI to the user
   // when processing a very large sync (could be useful for replacement syncs). Note that remote change count
   // is NaN in turbo mode.
-  onWillApplyRemoteChanges?: (info: $Exact<{ remoteChangeCount: number }>) => Promise<void>,
+  onWillApplyRemoteChanges?: (info: $Exact<{ remoteChangeCount: number }>) => Promise<void>;
 }>
 
 /**
@@ -143,6 +164,21 @@ export async function synchronize(args: SyncArgs): Promise<void> {
   try {
     const synchronizeImpl = require('./impl/synchronize').default
     await synchronizeImpl(args)
+  } catch (error) {
+    args.log && (args.log.error = error)
+    throw error
+  }
+}
+
+/**
+ * Does database push-only synchronize with a remote server
+ *
+ * See docs for more details
+ */
+export async function optimisticSyncPush(args: OptimisticSyncPushArgs): Promise<void> {
+  try {
+    const optimisticSyncPushImpl = require('./impl/synchronize').optimisticSyncPush
+    await optimisticSyncPushImpl(args)
   } catch (error) {
     args.log && (args.log.error = error)
     throw error

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -100,6 +100,11 @@ export type SyncArgs = $Exact<{
   // If you don't want to change default behavior for a given record, return `resolved` as is
   // Note that it's safe to mutate `resolved` object, so you can skip copying it for performance.
   conflictResolver?: SyncConflictResolver,
+  // experimental customization that will cause to only set records as synced if we return id.
+  // This will in turn cause all records to be re-pushed if id wasn't returned. This allows to
+  // "whitelisting" ids instead of "blacklisting" (rejectedIds) so that there is less chance that
+  // unpredicted error will cause data loss (when failed data push isn't re-pushed)
+  pushShouldConfirmOnlyAccepted?: boolean;
   // commits changes in multiple batches, and not one - temporary workaround for memory issue
   _unsafeBatchPerCollection?: boolean,
   // Advanced optimization - pullChanges must return syncJson or syncJsonId to be processed by native code.

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -59,9 +59,12 @@ export type SyncRejectedIds = SyncIds
 
 export type SyncPushArgs = $Exact<{ changes: SyncDatabaseChangeSet, lastPulledAt: Timestamp }>
 
+export type SyncPushResultSet = { [tableName: TableName<any>]: DirtyRaw[] }
+
 export type SyncPushResult = $Exact<{
   experimentalRejectedIds?: SyncIds,
   experimentalAcceptedIds?: SyncIds,
+  pushResultSet?: SyncPushResultSet,
 }>
 
 type SyncConflict = $Exact<{ local: DirtyRaw, remote: DirtyRaw, resolved: DirtyRaw }>
@@ -107,6 +110,12 @@ export type SyncArgs = $Exact<{
   // "whitelisting" ids instead of "blacklisting" (rejectedIds) so that there is less chance that
   // unpredicted error will cause data loss (when failed data push isn't re-pushed)
   pushShouldConfirmOnlyAccepted?: boolean;
+  // conflict resolver on push side of sync which also requires returned records from backend.
+  // This is also useful for multi-step sync where one must control in which state sync is and if it
+  // must be repeated.
+  // Note that by default _status will be still synced so update if required
+  // Note that it's safe to mutate `resolved` object, so you can skip copying it for performance.
+  pushConflictResolver?: SyncConflictResolver;
   // commits changes in multiple batches, and not one - temporary workaround for memory issue
   _unsafeBatchPerCollection?: boolean,
   // Advanced optimization - pullChanges must return syncJson or syncJsonId to be processed by native code.


### PR DESCRIPTION
When one works offline it usually makes sense to do both pull and push but on the other hand when one tries to push asap it might not always be desired to do full sync. One might for example want to push asap on web but not on native.
Even though WatermelonDB was initially designed with having single endpoint this isn't always the case either because of trying to use existing systems, having no control over systems or because there is need to have multiple endpoints. Previously pushing asap would do full sync and this combined with having multiple endpoints can trigger 10s of connections even when it would be mostly enough to do just one push connection. Because of so many connections even if data is minimal this can cause long execution times.
This PR essentially separates push part from synchronize and exposes it to lib-users.

This PR is related to multiple other PRs (#1738, #1552, #1548) which must be merged before. Since I don't know if any of these will be merged I am just pushing this here as is. All of these changes together will be available in our fork.