### PR TITLE
Add missing bracket to code snippet

### DIFF
--- a/docs-website/docs/docs/Components.md
+++ b/docs-website/docs/docs/Components.md
@@ -302,7 +302,7 @@ export default compose(
   withObservables([], ({ database }) => ({
     blogs: database.get('blogs').query(),
   }),
-)(BlogList)
+))(BlogList)
 
 ```
 


### PR DESCRIPTION
withDatabase code snippet is missing a bracket for the compose function. PR adds this to the docs to avoid minor head scratching.

Some docs on what compose is and does would be nice too!