### PR TITLE
Add destroyColumn and renameColumn migration steps

### DIFF
--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -8,6 +8,7 @@
 
 - Added `Database#experimentalIsVerbose` option
 - Added destroyColumn migration step
+- Added renameColumn migration step
 
 ### Fixes
 

--- a/CHANGELOG-Unreleased.md
+++ b/CHANGELOG-Unreleased.md
@@ -7,6 +7,7 @@
 ### New features
 
 - Added `Database#experimentalIsVerbose` option
+- Added destroyColumn migration step
 
 ### Fixes
 

--- a/src/RawRecord/index.d.ts
+++ b/src/RawRecord/index.d.ts
@@ -1,7 +1,6 @@
 import type { ColumnName, ColumnSchema, TableSchema } from '../Schema'
 import type { RecordId, SyncStatus } from '../Model'
 
-
 // Raw object representing a model record, coming from an untrusted source
 // (disk, sync, user data). Before it can be used to create a Model instance
 // it must be sanitized (with `sanitizedRaw`) into a RawRecord
@@ -15,7 +14,7 @@ type _RawRecord = {
 }
 
 // Raw object representing a model record. A RawRecord is guaranteed by the type system
-// to be safe to use (sanitied with `sanitizedRaw`):
+// to be safe to use (sanitized with `sanitizedRaw`):
 // - it has exactly the fields described by TableSchema (+ standard fields)
 // - every field is exactly the type described by ColumnSchema (string, number, or boolean)
 // - … and the same optionality (will not be null unless isOptional: true)

--- a/src/RawRecord/index.js
+++ b/src/RawRecord/index.js
@@ -20,7 +20,7 @@ type _RawRecord = {
 }
 
 // Raw object representing a model record. A RawRecord is guaranteed by the type system
-// to be safe to use (sanitied with `sanitizedRaw`):
+// to be safe to use (sanitized with `sanitizedRaw`):
 // - it has exactly the fields described by TableSchema (+ standard fields)
 // - every field is exactly the type described by ColumnSchema (string, number, or boolean)
 // - … and the same optionality (will not be null unless isOptional: true)

--- a/src/Schema/migrations/getSyncChanges/index.js
+++ b/src/Schema/migrations/getSyncChanges/index.js
@@ -15,6 +15,13 @@ export type MigrationSyncChanges = $Exact<{
     table: TableName<any>,
     columns: ColumnName[],
   }>[],
+  +renamedColumns: $Exact<{
+    table: TableName<any>,
+    columns: $Exact<{
+      from: ColumnName,
+      to: ColumnName,
+    }>[],
+  }>[],
 }> | null
 
 export default function getSyncChanges(
@@ -34,7 +41,7 @@ export default function getSyncChanges(
 
   steps.forEach((step) => {
     invariant(
-      ['create_table', 'add_columns', 'sql'].includes(step.type),
+      ['create_table', 'add_columns', 'sql', 'rename_column'].includes(step.type),
       `Unknown migration step type ${step.type}. Can not perform migration sync. This most likely means your migrations are defined incorrectly. It could also be a WatermelonDB bug.`,
     )
   })
@@ -63,9 +70,22 @@ export default function getSyncChanges(
     columns: unique(columnDefs.map(({ name }) => name)),
   }))
 
+  const allRenamedColumns = steps.filter(
+    (step) => step.type === 'rename_column' && !createdTables.includes(step.table),
+  )
+
+  const renamedColumns = pipe(
+    groupBy(({ table }) => table),
+    toPairs,
+  )(allRenamedColumns).map(([table, columns]) => ({
+    table: tableName(table),
+    columns: columns.map(({ from, to }) => ({ from, to })),
+  }))
+
   return {
     from: fromVersion,
     tables: unique(createdTables),
     columns: addedColumns,
+    renamedColumns,
   }
 }

--- a/src/Schema/migrations/index.d.ts
+++ b/src/Schema/migrations/index.d.ts
@@ -1,5 +1,12 @@
 import type { $RE, $Exact } from '../../types'
-import type { ColumnSchema, TableName, TableSchema, TableSchemaSpec, SchemaVersion } from '../index'
+import type {
+  ColumnName,
+  ColumnSchema,
+  TableName,
+  TableSchema,
+  TableSchemaSpec,
+  SchemaVersion,
+} from '../index'
 
 export type CreateTableMigrationStep = $RE<{
   type: 'create_table'
@@ -13,12 +20,22 @@ export type AddColumnsMigrationStep = $RE<{
   unsafeSql?: (_: string) => string
 }>
 
+export type DestroyColumnMigrationStep = $RE<{
+  type: 'destroy_column'
+  table: TableName<any>
+  column: ColumnName
+}>
+
 export type SqlMigrationStep = $RE<{
   type: 'sql'
   sql: string
 }>
 
-export type MigrationStep = CreateTableMigrationStep | AddColumnsMigrationStep | SqlMigrationStep
+export type MigrationStep =
+  | CreateTableMigrationStep
+  | AddColumnsMigrationStep
+  | SqlMigrationStep
+  | DestroyColumnMigrationStep
 
 type Migration = $RE<{
   toVersion: SchemaVersion
@@ -49,5 +66,13 @@ export function addColumns({
   columns: ColumnSchema[]
   unsafeSql?: (_: string) => string
 }>): AddColumnsMigrationStep
+
+export function destroyColumn({
+  table,
+  column,
+}: $Exact<{
+  table: TableName<any>
+  column: ColumnName
+}>): DestroyColumnMigrationStep
 
 export function unsafeExecuteSql(sql: string): SqlMigrationStep

--- a/src/Schema/migrations/index.d.ts
+++ b/src/Schema/migrations/index.d.ts
@@ -26,6 +26,13 @@ export type DestroyColumnMigrationStep = $RE<{
   column: ColumnName
 }>
 
+export type RenameColumnMigrationStep = $RE<{
+  type: 'rename_column'
+  table: TableName<any>
+  from: ColumnName
+  to: ColumnName
+}>
+
 export type SqlMigrationStep = $RE<{
   type: 'sql'
   sql: string
@@ -36,6 +43,7 @@ export type MigrationStep =
   | AddColumnsMigrationStep
   | SqlMigrationStep
   | DestroyColumnMigrationStep
+  | RenameColumnMigrationStep
 
 type Migration = $RE<{
   toVersion: SchemaVersion
@@ -74,5 +82,15 @@ export function destroyColumn({
   table: TableName<any>
   column: ColumnName
 }>): DestroyColumnMigrationStep
+
+export function renameColumn({
+  table,
+  from,
+  to,
+}: $Exact<{
+  table: TableName<any>
+  from: string
+  to: string
+}>): RenameColumnMigrationStep
 
 export function unsafeExecuteSql(sql: string): SqlMigrationStep

--- a/src/Schema/migrations/index.js
+++ b/src/Schema/migrations/index.js
@@ -7,7 +7,7 @@ import isObj from '../../utils/fp/isObj'
 
 import type { $RE } from '../../types'
 import type {
-  columnName,
+  ColumnName,
   ColumnSchema,
   TableName,
   TableSchema,
@@ -34,6 +34,13 @@ export type DestroyColumnMigrationStep = $RE<{
   column: ColumnName,
 }>
 
+export type RenameColumnMigrationStep = $RE<{
+  type: 'rename_column',
+  table: TableName<any>,
+  from: ColumnName,
+  to: ColumnName,
+}>
+
 export type SqlMigrationStep = $RE<{
   type: 'sql',
   sql: string,
@@ -44,6 +51,7 @@ export type MigrationStep =
   | AddColumnsMigrationStep
   | SqlMigrationStep
   | DestroyColumnMigrationStep
+  | RenameColumnMigrationStep
 
 type Migration = $RE<{
   toVersion: SchemaVersion,
@@ -198,6 +206,22 @@ export function unsafeExecuteSql(sql: string): SqlMigrationStep {
   return { type: 'sql', sql }
 }
 
+export function renameColumn({
+  table,
+  from,
+  to,
+}: $Exact<{
+  table: TableName<any>,
+  from: ColumnName,
+  to: ColumnName,
+}>): RenameColumnMigrationStep {
+  if (process.env.NODE_ENV !== 'production') {
+    invariant(table, `Missing table name in renameColumn()`)
+    invariant(from, `Missing 'from' in renameColumn()`)
+    invariant(to, `Missing 'to' in renameColumn()`)
+  }
+  return { type: 'rename_column', table, from, to }
+}
 /*
 
 TODO: Those types of migrations are currently not implemented. If you need them, feel free to contribute!
@@ -205,9 +229,6 @@ TODO: Those types of migrations are currently not implemented. If you need them,
 // table operations
 destroyTable('table_name')
 renameTable({ from: 'old_table_name', to: 'new_table_name' })
-
-// column operations
-renameColumn({ table: 'table_name', from: 'old_column_name', to: 'new_column_name' })
 
 // indexing
 addColumnIndex({ table: 'table_name', column: 'column_name' })

--- a/src/Schema/migrations/test.js
+++ b/src/Schema/migrations/test.js
@@ -1,4 +1,4 @@
-import { createTable, addColumns, destroyColumn, schemaMigrations } from './index'
+import { createTable, addColumns, destroyColumn, renameColumn, schemaMigrations } from './index'
 import { stepsForMigration } from './stepsForMigration'
 
 describe('schemaMigrations()', () => {
@@ -30,6 +30,10 @@ describe('schemaMigrations()', () => {
   it('returns a complex schema migrations spec', () => {
     const migrations = schemaMigrations({
       migrations: [
+        {
+          toVersion: 5,
+          steps: [renameColumn({ table: 'comments', from: 'text', to: 'body' })],
+        },
         {
           toVersion: 4,
           steps: [
@@ -76,7 +80,7 @@ describe('schemaMigrations()', () => {
     expect(migrations).toEqual({
       validated: true,
       minVersion: 1,
-      maxVersion: 4,
+      maxVersion: 5,
       sortedMigrations: [
         {
           toVersion: 2,
@@ -127,6 +131,17 @@ describe('schemaMigrations()', () => {
               type: 'destroy_column',
               table: 'comments',
               column: 'body',
+            },
+          ],
+        },
+        {
+          toVersion: 5,
+          steps: [
+            {
+              type: 'rename_column',
+              table: 'comments',
+              from: 'text',
+              to: 'body',
             },
           ],
         },
@@ -210,6 +225,11 @@ describe('migration step functions', () => {
   it('throws if destroyColumn() is malformed', () => {
     expect(() => destroyColumn({ column: 'foo' })).toThrow('table')
     expect(() => destroyColumn({ table: 'foo' })).toThrow('column')
+  })
+  it('throws if renameColumn() is malformed', () => {
+    expect(() => renameColumn({ from: 'text', to: 'body' })).toThrow('table')
+    expect(() => renameColumn({ table: 'foo', from: 'text' })).toThrow('to')
+    expect(() => renameColumn({ table: 'foo', to: 'body' })).toThrow('from')
   })
 })
 

--- a/src/Schema/migrations/test.js
+++ b/src/Schema/migrations/test.js
@@ -1,4 +1,4 @@
-import { createTable, addColumns, schemaMigrations } from './index'
+import { createTable, addColumns, destroyColumn, schemaMigrations } from './index'
 import { stepsForMigration } from './stepsForMigration'
 
 describe('schemaMigrations()', () => {
@@ -30,7 +30,19 @@ describe('schemaMigrations()', () => {
   it('returns a complex schema migrations spec', () => {
     const migrations = schemaMigrations({
       migrations: [
-        { toVersion: 4, steps: [] },
+        {
+          toVersion: 4,
+          steps: [
+            addColumns({
+              table: 'comments',
+              columns: [{ name: 'text', type: 'string' }],
+            }),
+            destroyColumn({
+              table: 'comments',
+              column: 'body',
+            }),
+          ],
+        },
         {
           toVersion: 3,
           steps: [
@@ -103,7 +115,21 @@ describe('schemaMigrations()', () => {
             },
           ],
         },
-        { toVersion: 4, steps: [] },
+        {
+          toVersion: 4,
+          steps: [
+            {
+              type: 'add_columns',
+              table: 'comments',
+              columns: [{ name: 'text', type: 'string' }],
+            },
+            {
+              type: 'destroy_column',
+              table: 'comments',
+              column: 'body',
+            },
+          ],
+        },
       ],
     })
   })
@@ -180,6 +206,10 @@ describe('migration step functions', () => {
     expect(() => addColumns({ table: 'foo', columns: [{ name: 'x', type: 'blah' }] })).toThrow(
       'type',
     )
+  })
+  it('throws if destroyColumn() is malformed', () => {
+    expect(() => destroyColumn({ column: 'foo' })).toThrow('table')
+    expect(() => destroyColumn({ table: 'foo' })).toThrow('column')
   })
 })
 

--- a/src/adapters/lokijs/worker/DatabaseDriver.js
+++ b/src/adapters/lokijs/worker/DatabaseDriver.js
@@ -390,6 +390,8 @@ export default class DatabaseDriver {
         this._executeCreateTableMigration(step)
       } else if (step.type === 'add_columns') {
         this._executeAddColumnsMigration(step)
+      } else if (step.type === 'destroy_column') {
+        this._executeDestroyColumnMigration(step)
       } else if (step.type === 'sql') {
         // ignore
       } else {
@@ -422,6 +424,14 @@ export default class DatabaseDriver {
       if (column.isIndexed) {
         collection.ensureIndex(column.name)
       }
+    })
+  }
+  _executeDestroyColumnMigration({ table, column }: DestroyColumnMigrationStep): void {
+    const collection = this.loki.getCollection(table)
+
+    // update ALL records in the collection, removing a field
+    collection.findAndUpdate({}, (record) => {
+      delete record[column]
     })
   }
 

--- a/src/adapters/sqlite/index.js
+++ b/src/adapters/sqlite/index.js
@@ -169,7 +169,7 @@ export default class SQLiteAdapter implements DatabaseAdapter {
         'setUpWithMigrations',
         [
           this.dbName,
-          require('./encodeSchema').encodeMigrationSteps(migrationSteps),
+          require('./encodeSchema').encodeMigrationSteps(migrationSteps, this.schema),
           databaseVersion,
           this.schema.version,
         ],

--- a/src/sync/impl/__tests__/synchronize-migration.test.js
+++ b/src/sync/impl/__tests__/synchronize-migration.test.js
@@ -1,6 +1,6 @@
 import { mockDatabase, testSchema } from '../../../__tests__/testModels'
 import { expectToRejectWithMessage } from '../../../__tests__/utils'
-import { schemaMigrations, createTable, addColumns } from '../../../Schema/migrations'
+import { schemaMigrations, createTable, addColumns, renameColumn } from '../../../Schema/migrations'
 import { emptyPull } from './helpers'
 
 import { synchronize } from '../../index'
@@ -17,6 +17,7 @@ describe('synchronize - migration syncs', () => {
             table: 'attachment_versions',
             columns: [{ name: 'reactions', type: 'string' }],
           }),
+          renameColumn({ table: 'post', from: 'body', to: 'text' }),
         ],
       },
       {
@@ -113,6 +114,7 @@ describe('synchronize - migration syncs', () => {
         from: 9,
         tables: [],
         columns: [{ table: 'attachment_versions', columns: ['reactions'] }],
+        renamedColumns: [{ table: 'post', columns: [{ from: 'body', to: 'text' }] }],
       },
     })
     expect(await getLastPulledSchemaVersion(database)).toBe(10)
@@ -135,6 +137,7 @@ describe('synchronize - migration syncs', () => {
         from: 8,
         tables: ['attachments'],
         columns: [{ table: 'attachment_versions', columns: ['reactions'] }],
+        renamedColumns: [{ table: 'post', columns: [{ from: 'body', to: 'text' }] }],
       },
     })
     expect(await getLastPulledSchemaVersion(database)).toBe(10)


### PR DESCRIPTION
This PR implements most of the outstanding code changes from 

https://github.com/Nozbe/WatermelonDB/pull/1671 and https://github.com/Nozbe/WatermelonDB/pull/1654.

In addition to resolving those conflicts it has a few minor syntactic / grammatical fixes to match the existing migration approaches.