### PR TITLE
Add json decorator options to TS type

### DIFF
--- a/src/decorators/json/index.d.ts
+++ b/src/decorators/json/index.d.ts
@@ -3,6 +3,11 @@ import Model from '../../Model'
 
 export type Sanitizer = (source: any, model?: Model) => any
 
-declare function json(rawFieldName: ColumnName, sanitizer: Sanitizer): PropertyDecorator
+export type Options = {
+  /** Use cached value if possible rather than sanitizing the raw value for every read. Default: `false` */
+  memo: boolean;
+}
+
+declare function json(rawFieldName: ColumnName, sanitizer: Sanitizer, options?: Options): PropertyDecorator
 
 export default json


### PR DESCRIPTION
Modifies the json property decorator TS type to support an options object as a third function argument that the [JS implementation](https://github.com/Nozbe/WatermelonDB/blob/master/src/decorators/json/index.js#L41) supports.