### PR TITLE
Introducing WatermelonDB Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
   <a href="https://www.npmjs.com/package/@nozbe/watermelondb">
     <img src="https://img.shields.io/npm/v/@nozbe/watermelondb.svg" alt="npm"/>
   </a>
+
+  <a href="https://gurubase.io/g/watermelondb">
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20WatermelonDB%20Guru-006BFF" alt="Gurubase"/>
+  </a>
 </p>
 
 |   | WatermelonDB |


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [WatermelonDB Guru](https://gurubase.io/g/watermelondb) to Gurubase. WatermelonDB Guru uses the data from this repo and data from the [docs](https://watermelondb.dev/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "WatermelonDB Guru", which highlights that WatermelonDB now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable WatermelonDB Guru in Gurubase, just let me know that's totally fine.
