### PR TITLE
Electron support 

### DIFF
--- a/docs-website/docs/docs/Installation.mdx
+++ b/docs-website/docs/docs/Installation.mdx
@@ -382,6 +382,26 @@ You only need this if you want to use WatermelonDB in NodeJS with SQLite (e.g. f
 
 ---
 
+## Electron (SQLite) setup
+
+You only need this if you want to use WatermelonDB in Electron with SQLite.
+
+1. Install [better-sqlite3](https://github.com/JoshuaWise/better-sqlite3) peer dependency
+
+   ```sh
+   yarn add --dev better-sqlite3
+
+   # (or with npm:)
+   npm install -D better-sqlite3
+   ```
+2. Run electron rebuild on sqlite3. This step is necessary to ensure the sqlite native build (.node) is compatible with Electron's version of Node.js. If you're using Electron Forge, this step will be performed for you during build **but not development**.
+
+  ```sh
+  npx electron-rebuild -f -w -t dev better-sqlite3
+  ```
+
+---
+
 ## Next steps
 
 ➡️ After Watermelon is installed, [**set it up**](./Setup.md)

--- a/examples/typescript/yarn.lock
+++ b/examples/typescript/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.7.tgz#f4f0d5530e8dbdf59b3451b9b3e594b6ba082e12"
-  integrity sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==
+"@babel/runtime@7.26.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
+  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
   dependencies:
     regenerator-runtime "^0.14.0"
 

--- a/src/adapters/remote/index.js
+++ b/src/adapters/remote/index.js
@@ -1,0 +1,102 @@
+// @flow
+
+import { type ResultCallback } from '../../utils/fp/Result'
+
+import type { RecordId } from '../../Model'
+import type { SerializedQuery } from '../../Query'
+import type { TableName, AppSchema } from '../../Schema'
+import type { SchemaMigrations } from '../../Schema/migrations'
+import type {
+  DatabaseAdapter,
+  CachedQueryResult,
+  CachedFindResult,
+  BatchOperation,
+  UnsafeExecuteOperations,
+} from '../type'
+
+type RemoteHandler = (op: string, args: any[], callback: ResultCallback<any>) => void;
+
+type RemoteAdapterOptions = {
+    schema: AppSchema, 
+    migrations?: SchemaMigrations,
+    handler: RemoteHandler,
+}
+
+export default class RemoteAdapter implements DatabaseAdapter {
+    schema: AppSchema
+    dbName: string
+    migrations: ?SchemaMigrations
+    handler: RemoteHandler
+
+    constructor(options: RemoteAdapterOptions) {
+        const { schema, migrations, handler } = options;
+
+        this.schema = schema
+        this.migrations = migrations
+        this.handler = handler
+    }
+
+    find(table: TableName<any>, id: RecordId, callback: ResultCallback<CachedFindResult>) {
+        this.handler('find', [table, id], callback)
+    }
+
+    query(query: SerializedQuery, callback: ResultCallback<CachedQueryResult>) {
+        this.handler('query', [query], callback)
+    }
+
+    queryIds(query: SerializedQuery, callback: ResultCallback<RecordId[]>) {
+        this.handler('queryIds', [query], callback) 
+    }
+
+    unsafeQueryRaw(query: SerializedQuery, callback: ResultCallback<any[]>) {
+        this.handler('unsafeQueryRaw', [query], callback) 
+    }
+
+    count(query: SerializedQuery, callback: ResultCallback<number>) {
+        this.handler('count', [query], callback) 
+    }
+
+    batch(operations: BatchOperation[], callback: ResultCallback<void>) {
+        this.handler('batch', [operations], callback) 
+    }
+
+    getDeletedRecords(tableName: TableName<any>, callback: ResultCallback<RecordId[]>) {
+        this.handler('getDeletedRecords', [tableName], callback) 
+    }
+
+    destroyDeletedRecords(
+        tableName: TableName<any>,
+        recordIds: RecordId[],
+        callback: ResultCallback<void>,
+    ) {
+        this.handler('batch', [tableName, recordIds], callback) 
+    }
+
+    unsafeLoadFromSync(jsonId: number, callback: ResultCallback<any>) {
+        this.handler('unsafeLoadFromSync', [jsonId], callback) 
+    }
+
+    provideSyncJson(id: number, syncPullResultJson: string, callback: ResultCallback<void>) {
+        this.handler('provideSyncJson', [id, syncPullResultJson], callback) 
+    }
+
+    unsafeResetDatabase(callback: ResultCallback<void>) {
+        this.handler('unsafeResetDatabase', [], callback) 
+    }
+
+    unsafeExecute(work: UnsafeExecuteOperations, callback: ResultCallback<void>) {
+        this.handler('unsafeExecute', [work], callback) 
+    }
+
+    getLocal(key: string, callback: ResultCallback<?string>) {
+        this.handler('getLocal', [key], callback) 
+    }
+
+    setLocal(key: string, value: string, callback: ResultCallback<void>) {
+        this.handler('getLocal', [key, value], callback) 
+    }
+
+    removeLocal(key: string, callback: ResultCallback<void>) {
+        this.handler('getLocal', [key], callback) 
+    }
+}

--- a/src/adapters/remote/type.d.ts
+++ b/src/adapters/remote/type.d.ts
@@ -1,0 +1,11 @@
+import { AppSchema } from "../../Schema";
+import { SchemaMigrations } from "../../Schema/migrations";
+import { ResultCallback } from "../../utils/fp/Result";
+
+type RemoteHandler = (op: string, args: any[], callback: ResultCallback<any>) => void;
+
+type RemoteAdapterOptions = {
+    schema: AppSchema, 
+    migrations?: SchemaMigrations,
+    handler: RemoteHandler,
+}

--- a/src/adapters/remote/type.js
+++ b/src/adapters/remote/type.js
@@ -1,0 +1,13 @@
+// @flow
+
+import { type ResultCallback } from '../../utils/fp/Result'
+import type { AppSchema } from '../../Schema'
+import type { SchemaMigrations } from '../../Schema/migrations'
+
+type RemoteHandler = (op: string, args: any[], callback: ResultCallback<any>) => void;
+
+export type RemoteAdapterOptions = {
+    schema: AppSchema, 
+    migrations?: SchemaMigrations,
+    handler: RemoteHandler,
+}


### PR DESCRIPTION
- Added remote adapter class which takes a callback used to actually execute queries. Implementers can provide a callback using any transport they want. I've added an example using electron's IPC to the docs. 
- This approach assumes arguments and response values passed to the adapter are serializable (Electron uses standard [structured clone](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)). Please let me know if this assumption is faulty. The alternative (and maybe better?) way is fully re-implementing the sqlite adapter but I'm trying to be lazy 😉.

Not really sure if this should be a draft or not, tests pass but I haven't added any extra for the new code. I won't have much time to work on this PR further but at the very least, might be helpful as reference for anyone trying to implement something similar. 