### PR TITLE
Fix WMDatabaseBridge compatibility with Bridgeless architecture

### DIFF
--- a/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseBridge.java
+++ b/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseBridge.java
@@ -248,7 +248,7 @@ public class WMDatabaseBridge extends ReactContextBaseJavaModule {
     public void invalidate() {
         // NOTE: See Database::install() for explanation
         super.invalidate();
-        reactContext.getJSMessageQueueThread().runOnQueue(() -> {
+        reactContext.runOnJSQueueThread(() -> {
             try {
                 Class<?> clazz = Class.forName("com.nozbe.watermelondb.jsi.WatermelonJSI");
                 Method method = clazz.getDeclaredMethod("onCatalystInstanceDestroy");

--- a/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseBridge.java
+++ b/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseBridge.java
@@ -248,7 +248,7 @@ public class WMDatabaseBridge extends ReactContextBaseJavaModule {
     public void invalidate() {
         // NOTE: See Database::install() for explanation
         super.invalidate();
-        reactContext.getCatalystInstance().getReactQueueConfiguration().getJSQueueThread().runOnQueue(() -> {
+        reactContext.getJSMessageQueueThread().runOnQueue(() -> {
             try {
                 Class<?> clazz = Class.forName("com.nozbe.watermelondb.jsi.WatermelonJSI");
                 Method method = clazz.getDeclaredMethod("onCatalystInstanceDestroy");


### PR DESCRIPTION
This pull request addresses the following `NullPointerException` that occurs on app reload in the new architecture:
```java
Caused by: java.lang.NullPointerException
    at com.facebook.react.runtime.BridgelessCatalystInstance.getReactQueueConfiguration(BridgelessCatalystInstance.kt:116)
    at com.nozbe.watermelondb.WMDatabaseBridge.invalidate(WMDatabaseBridge.java:251)
    at com.facebook.react.internal.turbomodule.core.TurboModuleManager.invalidate(TurboModuleManager.java:417)
    at com.facebook.react.runtime.ReactInstance.destroy(ReactInstance.java:462)
    at com.facebook.react.runtime.ReactHostImpl.lambda$getOrCreateDestroyTask$41(ReactHostImpl.java:1701)
    at com.facebook.react.runtime.ReactHostImpl.$r8$lambda$JjSvGyrjIWnRG8yxfoNdD4824hc(Unknown Source:0)
    at com.facebook.react.runtime.ReactHostImpl$$ExternalSyntheticLambda32.then(D8$$SyntheticClass:0)
    at com.facebook.react.runtime.internal.bolts.Task$8.run(Task.java:460)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) 
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644) 
    at java.lang.Thread.run(Thread.java:1012) 
```

This issue arises because the new **Bridgeless architecture** does not support `CatalystInstance`, as described in the [React Native source code](https://github.com/facebook/react-native/blob/980458c061580bbc004bf1ddc17f567fc51aaab8/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java#L86-L89).

This change updates `WMDatabaseBridge` to use `runOnJSQueueThread()` instead of `getCatalystInstance().getReactQueueConfiguration().getJSQueueThread().runOnQueue()`, ensuring compatibility with the Bridgeless architecture.