### PR TITLE
Update sqlite makeDispatcher to show correct method name in error

### DIFF
--- a/src/adapters/sqlite/makeDispatcher/index.native.js
+++ b/src/adapters/sqlite/makeDispatcher/index.native.js
@@ -91,7 +91,7 @@ class SqliteJsiDispatcher implements SqliteDispatcher {
       const method = this._db[methodName]
       if (!method) {
         throw new Error(
-          `Cannot run database method ${method} because database failed to open. Hint: Did you install JSI correctly? This happens if you forgot to configure Proguard correctly ${Object.keys(
+          `Cannot run database method ${methodName} because database failed to open. Hint: Did you install JSI correctly? This happens if you forgot to configure Proguard correctly ${Object.keys(
             this._db,
           ).join(',')}`,
         )


### PR DESCRIPTION
Currently, the error shows `Cannot run database method undefined because database failed to open. Hint: Did you install JSI correctly? ...` when a user tries to call an unsupported method. 

Updated to show the method name the user is trying to call.