### PR TITLE
Support for 16kb page size for watermelondb-jni

### DIFF
--- a/native/android-jsi/src/main/cpp/CMakeLists.txt
+++ b/native/android-jsi/src/main/cpp/CMakeLists.txt
@@ -83,6 +83,9 @@ add_library(watermelondb-jsi SHARED
         # seems wrong to compile a file that's already getting compiled as part of the app, but ¯\_(ツ)_/¯
         ${NODE_MODULES_PATH_RN}/react-native/ReactCommon/jsi/jsi/jsi.cpp)
 
+# Enable Android 16kb native library alignment
+target_link_options(watermelondb-jsi PRIVATE "-Wl,-z,max-page-size=16384")
+
 target_link_libraries(watermelondb-jsi
                       # link with these libraries:
                       android


### PR DESCRIPTION
New Android apps and app updates will [require native libraries to be built with 16kb page size support](https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html). **This will become a required change by November 1st 2025.** Currently, building with watermelondb-jni results in the following two warnings for published apps on Google Play Console:

![image](https://github.com/user-attachments/assets/bb4aacbe-4d74-4bd4-99b7-139ea25deb3a)
![image](https://github.com/user-attachments/assets/57b43713-c954-47d2-a04b-acab8a536e22)

The [update guide](https://developer.android.com/guide/practices/page-sizes#compile-r26-lower) recommends this change for CMake projects and after checking the alignment of the x86_64 and arm64-v8a (the two architectures that will require 16kb support) libraries, this change successfully builds with 2**14 alignment.

After some rudimentary testing on the [new 16kb page size emulator image](https://developer.android.com/guide/practices/page-sizes#16kb-emulator) WatermelonDB seems to work as usual after this change, at least in the case of our app.