### PR TITLE
fix: make catchError visible to typescript

### DIFF
--- a/src/utils/rx/__wmelonRxShim/index.d.ts
+++ b/src/utils/rx/__wmelonRxShim/index.d.ts
@@ -24,5 +24,6 @@ export {
   switchMap,
   throttleTime,
   startWith,
+  catchError
 } from 'rxjs/operators'
 export type { ConnectableObservable } from 'rxjs'

--- a/src/utils/rx/index.d.ts
+++ b/src/utils/rx/index.d.ts
@@ -22,5 +22,6 @@ export {
   switchMap,
   throttleTime,
   startWith,
+  catchError
 } from './__wmelonRxShim'
 export type { ConnectableObservable } from './__wmelonRxShim'


### PR DESCRIPTION
`catchError` is very useful when finding and observing a model and that model possibly doesnt exist which then throws an error in that case `catchError` is used to handle the error. It is already being exposed and can be used but Typescript doesnt see the type definition.

I just exported it from the .d.ts files like the other operators