### PR TITLE
Update Installation.mdx

### DIFF
--- a/docs-website/docs/docs/Installation.mdx
+++ b/docs-website/docs/docs/Installation.mdx
@@ -186,7 +186,6 @@ additional steps manually.
     ```
     // ...
     import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage // ⬅️ This!
-    import com.facebook.react.bridge.JSIModulePackage // ⬅️ This!
     // ...
     override val reactNativeHost: ReactNativeHost =
       object : DefaultReactNativeHost(this) {


### PR DESCRIPTION
This import is causing an error because the module is not resolved. If we remove this import, the build is successful, and the DB works completely fine.